### PR TITLE
chore: Update 200-lambda.md

### DIFF
--- a/workshop/content/30-hello-cdk/200-lambda.md
+++ b/workshop/content/30-hello-cdk/200-lambda.md
@@ -46,15 +46,6 @@ module and all it's dependencies into our project:
 npm install @aws-cdk/aws-lambda@0.22.0
 ```
 
-{{% notice info %}}
-
-**Windows users**: on Windows, you will have to stop the `npm run watch` command
-that is running in the background, then run `npm install`, then start
-`npm run watch` again. Otherwise you will get an error about files being
-in use.
-
-{{% /notice %}}
-
 Output should look like this:
 
 ```


### PR DESCRIPTION
Removed warning to Windows users about running "npm install @aws-cdk/aws-*" when "npm run watch" is running in another window.

I need someone else to confirm. If the warning is no longer valid, we also need to remove it from:

- 30-hello-cdk/300-apigw.md
- 40-hit-counter/300-resources.md
- 50-table-viewer/200-install.md

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
