### PR TITLE
chore: Update 100-api.md

### DIFF
--- a/workshop/content/40-hit-counter/100-api.md
+++ b/workshop/content/40-hit-counter/100-api.md
@@ -25,6 +25,8 @@ export class HitCounter extends cdk.Construct {
 }
 ```
 
+Save the file. Oops, an error! No worries, we'll be using `props` shortly.
+
 ## What's going on here?
 
 * We declared a new construct class called `HitCounter`.


### PR DESCRIPTION
Let user know to expect an error when they save hitcounter.ts before we use props.

*Issue #, if available:*

*Description of changes:*
Added warning when they save hitcounter.ts before it uses props.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
