### PR TITLE
fix: Over-indented image references

### DIFF
--- a/workshop/content/40-hit-counter/500-logs.md
+++ b/workshop/content/40-hit-counter/500-logs.md
@@ -15,22 +15,22 @@ you how to find your logs through the AWS console.
 
 #. Open the [AWS Lambda console](https://console.aws.amazon.com/lambda/home) (make sure you
    are connected to the correct region).
-   
-#. Click on the __HitCounter__ Lambda function 
+
+#. Click on the __HitCounter__ Lambda function
    (the name should contain the string `CdkWorkshopStack-HelloHitCounter`):
 
-    ![](./logs1.png)
+![](./logs1.png)
 
 #. Click on __Monitoring__
 
-    ![](./logs2.png)
+![](./logs2.png)
 
 #. Click on __View on CloudWatch Logs__. This will open the AWS CloudWatch console.
 
-    ![](./logs3.png)
+![](./logs3.png)
 
 #. Select the most-recent log group.
-    
+
 #. Look for the most-recent message containing the string "errorMessage". You'll likely see something like this:
 
 

--- a/workshop/content/40-hit-counter/500-logs.md
+++ b/workshop/content/40-hit-counter/500-logs.md
@@ -13,45 +13,42 @@ CLI](https://github.com/awslabs/aws-sam-cli) and
 [awslogs](https://github.com/jorgebastida/awslogs). In this workshop, we'll show
 you how to find your logs through the AWS console.
 
-#. Open the [AWS Lambda console](https://console.aws.amazon.com/lambda/home) (make sure you
+1. Open the [AWS Lambda console](https://console.aws.amazon.com/lambda/home) (make sure you
    are connected to the correct region).
 
-#. Click on the __HitCounter__ Lambda function
+2. Click on the __HitCounter__ Lambda function
    (the name should contain the string `CdkWorkshopStack-HelloHitCounter`):
+    ![](./logs1.png)
 
-![](./logs1.png)
+3. Click on __Monitoring__
+    ![](./logs2.png)
 
-#. Click on __Monitoring__
+4. Click on __View on CloudWatch Logs__. This will open the AWS CloudWatch console.
+    ![](./logs3.png)
 
-![](./logs2.png)
+5. Select the most-recent log group.
 
-#. Click on __View on CloudWatch Logs__. This will open the AWS CloudWatch console.
-
-![](./logs3.png)
-
-#. Select the most-recent log group.
-
-#. Look for the most-recent message containing the string "errorMessage". You'll likely see something like this:
+6. Look for the most-recent message containing the string "errorMessage". You'll likely see something like this:
 
 
-    ```json
-    {
-        "errorMessage": "User: arn:aws:sts::585695036304:assumed-role/CdkWorkshopStack-HelloHitCounterHitCounterHandlerS-TU5M09L1UBID/CdkWorkshopStack-HelloHitCounterHitCounterHandlerD-144HVUNEWRWEO is not authorized to perform: dynamodb:UpdateItem on resource: arn:aws:dynamodb:us-east-1:585695036304:table/CdkWorkshopStack-HelloHitCounterHits7AAEBF80-1DZVT3W84LJKB",
-        "errorType": "AccessDeniedException",
-        "stackTrace": [
-            "Request.extractError (/var/runtime/node_modules/aws-sdk/lib/protocol/json.js:48:27)",
-            "Request.callListeners (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:105:20)",
-            "Request.emit (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:77:10)",
-            "Request.emit (/var/runtime/node_modules/aws-sdk/lib/request.js:683:14)",
-            "Request.transition (/var/runtime/node_modules/aws-sdk/lib/request.js:22:10)",
-            "AcceptorStateMachine.runTo (/var/runtime/node_modules/aws-sdk/lib/state_machine.js:14:12)",
-            "/var/runtime/node_modules/aws-sdk/lib/state_machine.js:26:10",
-            "Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:38:9)",
-            "Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:685:12)",
-            "Request.callListeners (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:115:18)"
-        ]
-    }
-    ```
+   ```json
+   {
+       "errorMessage": "User: arn:aws:sts::585695036304:assumed-role/CdkWorkshopStack-HelloHitCounterHitCounterHandlerS-TU5M09L1UBID/CdkWorkshopStack-HelloHitCounterHitCounterHandlerD-144HVUNEWRWEO is not authorized to perform: dynamodb:UpdateItem on resource: arn:aws:dynamodb:us-east-1:585695036304:table/CdkWorkshopStack-HelloHitCounterHits7AAEBF80-1DZVT3W84LJKB",
+       "errorType": "AccessDeniedException",
+       "stackTrace": [
+           "Request.extractError (/var/runtime/node_modules/aws-sdk/lib/protocol/json.js:48:27)",
+           "Request.callListeners (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:105:20)",
+           "Request.emit (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:77:10)",
+           "Request.emit (/var/runtime/node_modules/aws-sdk/lib/request.js:683:14)",
+           "Request.transition (/var/runtime/node_modules/aws-sdk/lib/request.js:22:10)",
+           "AcceptorStateMachine.runTo (/var/runtime/node_modules/aws-sdk/lib/state_machine.js:14:12)",
+           "/var/runtime/node_modules/aws-sdk/lib/state_machine.js:26:10",
+           "Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:38:9)",
+           "Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:685:12)",
+           "Request.callListeners (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:115:18)"
+       ]
+   }
+   ```
 
 ---
 


### PR DESCRIPTION
Indented with 4 spaces, they are rendered as inline code blocks, which
prevents the image to be referenced. Reduced the indent to 3 spaces
(matching the surroundings) fixes that.

Also fixed the numbered points syntax so they render correctly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
