### PR TITLE
Add emacs to ide list w/ reference to tide-mode

### DIFF
--- a/workshop/content/15-prerequisites/400-ide.md
+++ b/workshop/content/15-prerequisites/400-ide.md
@@ -15,4 +15,5 @@ We highly recommend to use an IDE that supports TypeScript type annotations
  - [Atom](https://atom.io/) with the [atom-typescript](https://atom.io/packages/atom-typescript) plugin
  - [vim](https://www.vim.org/) with [tsuquyomi](https://github.com/Quramy/tsuquyomi)
  - [WebStorm](https://www.jetbrains.com/help/webstorm/typescript-support.html)
+ - [Emacs](https://www.gnu.org/software/emacs/) with the [tide](https://github.com/ananthakumaran/tide) mode
 


### PR DESCRIPTION
*Description of changes:*

Add `emacs` with `tide-mode` to IDE page.  (I've been using it in the workshop with excellent results.)

As far as testing goes, I did an `npm run build`, stood up the hugo site locally on 1313 and was able to browse the site content without issue.  I didn't see any other tests that I could run. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
