### PR TITLE
Suggest using Cloud9

### DIFF
--- a/workshop/content/15-prerequisites/_index.md
+++ b/workshop/content/15-prerequisites/_index.md
@@ -11,7 +11,7 @@ To perform this workshop, you'll need the following:
 {{% children showhidden="false" %}}
 
 You can skip any of these steps if you have these tools already installed on
-your machine.
+your machine. Alternatively, you could use [AWS Cloud9](https://aws.amazon.com/cloud9/) and only install the AWS CDK Toolkit in your Cloud9 environment.
 
 Click on the arrow to the right to continue to the first step.
 


### PR DESCRIPTION
I think that suggesting Cloud9 as soon as possible will improve the workshop experience. This way, most users will be able to skip most of the Prerequisites section and move forward faster during the workshop.

*Description of changes:*

I've only added a suggestion about using AWS Cloud9 as soon as possible in the prerequisites section (we also mention it in the "IDE for TypeScript" section, but at the point a user might have already spent 10+ minutes installing AWS CLI, node, etc.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
