### PR TITLE
Fixes Documentation Code Typo

### DIFF
--- a/workshop/content/50-table-viewer/400-expose-table.md
+++ b/workshop/content/50-table-viewer/400-expose-table.md
@@ -63,7 +63,7 @@ import { TableViewer } from 'cdk-dynamo-table-viewer';
 
 export class CdkWorkshopStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
-    super(scope, name, props);
+    super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
       runtime: lambda.Runtime.NodeJS810,


### PR DESCRIPTION
Fixes issue #32  where constructor and super arguments are not the same, causing errors should the code be copy / pasted

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
