### PR TITLE
Fix broken link to AWS Construct Library reference

### DIFF
--- a/workshop/content/30-hello-cdk/200-lambda.md
+++ b/workshop/content/30-hello-cdk/200-lambda.md
@@ -35,7 +35,7 @@ each AWS service. For example, if you want to define an AWS Lambda function, we
 will need to use the AWS Lambda construct library.
 
 To discover and learn about AWS constructs, you can browse the [AWS Construct
-Library reference](https://awslabs.github.io/aws-cdk/reference.html).
+Library reference](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-construct-library.html).
 
 ![](./clib.png)
 


### PR DESCRIPTION
Previous link no longer working, I believe the new one is the most relevant equivalent

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
