### PR TITLE
Fixing texts that mention TypeScript in Python workshop

### DIFF
--- a/workshop/content/30-python/20-create-project/300-structure.md
+++ b/workshop/content/30-python/20-create-project/300-structure.md
@@ -52,7 +52,7 @@ This code loads and instantiates two instances of the `MyStack` class from
 
 ## The main stack
 
-Open up `hello/hello_stack.ts`. This is where the meat of our application
+Open up `hello/hello_stack.py`. This is where the meat of our application
 is:
 
 ```python

--- a/workshop/content/30-python/20-create-project/_index.md
+++ b/workshop/content/30-python/20-create-project/_index.md
@@ -6,7 +6,7 @@ weight = 20
 
 # Creating your first CDK project
 
-In this chapter we will use `cdk init` to create a new AWS CDK TypeScript project.
+In this chapter we will use `cdk init` to create a new AWS CDK Python project.
 
 We will also learn how to use the CDK Toolkit to synthesize an AWS
 CloudFormation template for the starter app and how to deploy your app into your

--- a/workshop/content/30-python/30-hello-cdk/200-lambda.md
+++ b/workshop/content/30-python/30-hello-cdk/200-lambda.md
@@ -43,7 +43,7 @@ Library reference](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-construct
 
 ![](./clib.png)
 
-Okay, let's use `npm install` (or in short `npm i`) to install the AWS Lambda
+Okay, let's use `pip install` to install the AWS Lambda
 module and all it's dependencies into our project:
 
 ```console

--- a/workshop/content/30-python/40-hit-counter/300-resources.md
+++ b/workshop/content/30-python/40-hit-counter/300-resources.md
@@ -15,7 +15,7 @@ have the Lambda library installed):
 pip install aws_cdk.aws_dynamodb
 ```
 
-Now, go back to `lib/hitcounter.ts` and add the following highlighted code:
+Now, go back to `hello/hitcounter.py` and add the following highlighted code:
 
 {{<highlight ts "hl_lines=3 16-19 21-29">}}
 from aws_cdk import (
@@ -33,7 +33,7 @@ class HitCounter(core.Construct):
     def __init__(self, scope: core.Construct, id: str, downstream: _lambda.IFunction, **kwargs):
         super().__init__(scope, id, **kwargs)
 
-        table = new ddb.Table(
+        table = ddb.Table(
             self, 'Hits',
             partition_key={'name': 'path', 'type': ddb.AttributeType.STRING}
         )

--- a/workshop/content/30-python/40-hit-counter/400-use.md
+++ b/workshop/content/30-python/40-hit-counter/400-use.md
@@ -51,7 +51,7 @@ relayed back in the reverse order all the way to the user.
 ## Deploy
 
 ```console
-cdk deploy
+cdk deploy hello-cdk-1
 ```
 
 And the output:

--- a/workshop/content/30-python/40-hit-counter/600-permissions.md
+++ b/workshop/content/30-python/40-hit-counter/600-permissions.md
@@ -7,7 +7,7 @@ weight = 600
 
 Let's give our Lambda's execution role permissions to read/write from our table.
 
-Go back to `hitcounter.ts` and add the following highlighted lines:
+Go back to `hitcounter.py` and add the following highlighted lines:
 
 {{<highlight python "hl_lines=32">}}
 from aws_cdk import (
@@ -109,7 +109,7 @@ But, we must also give our hit counter permissions to invoke the downstream lamb
 
 ## Grant invoke permissions
 
-Add the highlighted lines to `lib/hitcounter.ts`:
+Add the highlighted lines to `hello/hitcounter.py`:
 
 {{<highlight ts "hl_lines=33-34">}}
 from aws_cdk import (


### PR DESCRIPTION
*Description of changes:*
- Changing `new AWS CDK TypeScript project` to `new AWS CDK Python project`
- Changing .ts to .py
- Changing npm to pip


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
