### PR TITLE
Few typescript references in Python workshop

### DIFF
--- a/workshop/content/30-python/30-hello-cdk/200-lambda.md
+++ b/workshop/content/30-python/30-hello-cdk/200-lambda.md
@@ -61,7 +61,7 @@ help you with auto-complete, inline documentation and type safety.
 
 ## Add an AWS Lambda Function to your stack
 
-Add an `import` statement at the beginning of `lib/cdk-workshop-stack.py`, and a
+Add an `import` statement at the beginning of `hello/hello_stack.py`, and a
 `lambda.Function` to your stack.
 
 

--- a/workshop/content/30-python/30-hello-cdk/200-lambda.md
+++ b/workshop/content/30-python/30-hello-cdk/200-lambda.md
@@ -47,7 +47,7 @@ Okay, let's use `pip install` to install the AWS Lambda
 module and all it's dependencies into our project:
 
 ```console
-pip install aws-cdk.aws_lambda
+pip install aws-cdk.aws-lambda
 ```
 
 ## A few words about copying & pasting in this workshop

--- a/workshop/content/30-python/30-hello-cdk/200-lambda.md
+++ b/workshop/content/30-python/30-hello-cdk/200-lambda.md
@@ -61,7 +61,7 @@ help you with auto-complete, inline documentation and type safety.
 
 ## Add an AWS Lambda Function to your stack
 
-Add an `import` statement at the beginning of `lib/cdk-workshop-stack.ts`, and a
+Add an `import` statement at the beginning of `lib/cdk-workshop-stack.py`, and a
 `lambda.Function` to your stack.
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pip project name typo, plus a filename from typescript version of workshop carried over into the python one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
