### PR TITLE
Remove duplicate step & fix handler

### DIFF
--- a/workshop/content/30-python/40-hit-counter/300-resources.md
+++ b/workshop/content/30-python/40-hit-counter/300-resources.md
@@ -8,13 +8,6 @@ weight = 300
 Now, let's define the AWS Lambda function and the DynamoDB table in our
 `HitCounter` construct.
 
-As usual, we first need to install the DynamoDB construct library (we already
-have the Lambda library installed):
-
-```console
-pip install aws_cdk.aws_dynamodb
-```
-
 Now, go back to `hello/hitcounter.py` and add the following highlighted code:
 
 {{<highlight ts "hl_lines=3 16-19 21-29">}}
@@ -38,7 +31,7 @@ class HitCounter(core.Construct):
             partition_key={'name': 'path', 'type': ddb.AttributeType.STRING}
         )
 
-        self._handler = _lambda.Function(
+        self.handler = _lambda.Function(
             self, 'HitCountHandler',
             runtime=_lambda.Runtime.PYTHON_3_7,
             handler='hitcount.handler',


### PR DESCRIPTION
*Description of changes:* Initial step to install dynamodb construct library is duplicate from previous workshop step (200-handler.md).

Handler is defined as self._handler but all future steps reference the handler as only '.handler' fixing here will resolve issue in future steps (400-use.md & 600-permissions.md)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
