### PR TITLE
Highlighted lines to show changes in sample

### DIFF
--- a/workshop/content/30-python/50-table-viewer/400-expose-table.md
+++ b/workshop/content/30-python/50-table-viewer/400-expose-table.md
@@ -7,7 +7,7 @@ weight = 400
 
 Edit `hitcounter.ts` and modify it as such `table` is exposed as a public property.
 
-{{<highlight python "hl_lines=13-15">}}
+{{<highlight python "hl_lines=13-15 20 32 36">}}
 from aws_cdk import (
     aws_lambda as _lambda,
     aws_dynamodb as ddb,


### PR DESCRIPTION
*Description of changes:* Following lines need to be highlighted as they are different from the original definition of this file in both /workshop/content/30-python/40-hit-counter/300-resources.md and /workshop/content/30-python/40-hit-counter/600-permissions.md. This is since the addition of the table @property.

20 - change from table to self._table
32 - change from table to self.table
36 - change from table to self.table

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
