### PR TITLE
Use backslashes in Windows virtualenv activation

### DIFF
--- a/workshop/content/30-python/20-create-project/200-virtualenv.md
+++ b/workshop/content/30-python/20-create-project/200-virtualenv.md
@@ -24,7 +24,7 @@ source .env/bin/activate
 One a Windows platform, you would use this:
 
 ```console
-.env/Scripts/activate.bat
+.env\Scripts\activate.bat
 ```
 
 Now that the virtual environment is activated, you can safely install the


### PR DESCRIPTION
Windows usually is slash-agnostic, but this is one place where it actually requires the backslashes to work.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
