### PR TITLE
Add note about adding Python to PATH on Windows to Python prerequisites

### DIFF
--- a/workshop/content/15-prerequisites/600-python.md
+++ b/workshop/content/15-prerequisites/600-python.md
@@ -7,3 +7,12 @@ If you are planning on using the Python Workshop, you obviously will need to
 have Python installed.  Specifically, you will need version 3.6 or later.  You
 can find information about downloading and installing Python
 [here](https://www.python.org/downloads/).
+
+If you use Windows, be sure Python is on your PATH. To see if it is, type `python`
+at a command prompt. The easiest way to make sure Python is on your PATH is to tick the
+**Add Python 3.x to PATH** checkbox on the first screen of the Python installer wizard.
+If you already have Python installed, but it's not on your PATH, you can add it by
+editing the `PATH` environment variable. To edit environment variables, click the 
+**Environment Variables** button in the Advanced page of Windows' System Properties.
+(Quickest way to get there: press and release the Windows key, type **env**, and 
+choose **Edit the system environment variables** from the Start menu.)


### PR DESCRIPTION
Might be better if the CDK would call `py` on Windows but as long as it's calling `python`, users need to make sure it's on the PATH.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
