### PR TITLE
Remove console syntax hinting on console sessions to avoid coloring random words

### DIFF
--- a/workshop/content/15-prerequisites/200-account.md
+++ b/workshop/content/15-prerequisites/200-account.md
@@ -45,7 +45,7 @@ the __access key ID__ and __secret key__ and choose a default region (you can
 use `us-east-1`, `eu-west-1`, `us-west-2` for example). Preferably use a region
 that doesn't have any resources already deployed into it.
 
-```console
+```
 aws configure
 ```
 

--- a/workshop/content/15-prerequisites/300-nodejs.md
+++ b/workshop/content/15-prerequisites/300-nodejs.md
@@ -13,7 +13,7 @@ The AWS CDK uses Node.js (>= 8.12.0).
 
 * If you already have Node.js installed, verify that you have a compatible version:
 
-    ```console
+    ```
     node --version
     ```
 

--- a/workshop/content/15-prerequisites/500-toolkit.md
+++ b/workshop/content/15-prerequisites/500-toolkit.md
@@ -11,13 +11,13 @@ Open a terminal session and run the following command:
 - Windows: you'll need to run this as an Administrator
 - POSIX: on some systems you may need to run this with `sudo`
 
-```console
+```
 npm install -g aws-cdk
 ```
 
 You can check the toolkit version:
 
-```console
+```
 $ cdk --version
 {{% cdkversion %}}
 ```

--- a/workshop/content/20-typescript/20-create-project/100-cdk-init.md
+++ b/workshop/content/20-typescript/20-create-project/100-cdk-init.md
@@ -7,7 +7,7 @@ weight = 100
 
 Create an empty directory on your system:
 
-```console
+```
 mkdir cdk-workshop && cd cdk-workshop
 ```
 
@@ -15,7 +15,7 @@ mkdir cdk-workshop && cd cdk-workshop
 
 We will use `cdk init` to create a new TypeScript CDK project:
 
-```console
+```
 cdk init sample-app --language typescript
 ```
 

--- a/workshop/content/20-typescript/20-create-project/200-watch.md
+++ b/workshop/content/20-typescript/20-create-project/200-watch.md
@@ -22,13 +22,13 @@ background for the duration of the workshop.
 
 From your project directory run:
 
-```console
+```
 cd cdk-workshop
 ```
 
 And:
 
-```console
+```
 npm run watch
 ```
 

--- a/workshop/content/20-typescript/20-create-project/400-synth.md
+++ b/workshop/content/20-typescript/20-create-project/400-synth.md
@@ -13,7 +13,7 @@ application.
 To synthesize a CDK app, use the `cdk synth` command. Let's check out the
 template synthesized from the sample app:
 
-```console
+```
 cdk synth
 ```
 

--- a/workshop/content/20-typescript/20-create-project/500-deploy.md
+++ b/workshop/content/20-typescript/20-create-project/500-deploy.md
@@ -15,7 +15,7 @@ bucket that is used to store templates and assets during the deployment process.
 You can use the `cdk bootstrap` command to install the bootstrap stack into an
 environment:
 
-```console
+```
 cdk bootstrap
 ```
 
@@ -32,7 +32,7 @@ Hopefully this command finished successfully and we can move on to deploy our ap
 
 Use `cdk deploy` to deploy a CDK app:
 
-```console
+```
 cdk deploy
 ```
 

--- a/workshop/content/20-typescript/30-hello-cdk/100-cleanup.md
+++ b/workshop/content/20-typescript/30-hello-cdk/100-cleanup.md
@@ -29,7 +29,7 @@ Now, that we modified our stack's contents, we can ask the toolkit to show us
 what will happen if we run `cdk deploy` (the difference between our CDK app and
 what's currently deployed):
 
-```console
+```
 cdk diff
 ```
 
@@ -59,7 +59,7 @@ As expected, all of our resources are going to be brutally destroyed.
 
 Run `cdk deploy` and __proceed to the next section__ (no need to wait):
 
-```console
+```
 cdk deploy
 ```
 

--- a/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
+++ b/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
@@ -42,7 +42,7 @@ Library reference](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-construct
 Okay, let's use `npm install` (or in short `npm i`) to install the AWS Lambda
 module and all it's dependencies into our project:
 
-```console
+```
 npm install @aws-cdk/aws-lambda
 ```
 
@@ -135,7 +135,7 @@ signature:
 
 Save your code, and let's take a quick look at the diff before we deploy:
 
-```console
+```
 cdk diff
 ```
 
@@ -176,7 +176,7 @@ that are used by the toolkit to propagate the location of the handler code.
 
 Let's deploy:
 
-```console
+```
 cdk deploy
 ```
 

--- a/workshop/content/20-typescript/30-hello-cdk/300-apigw.md
+++ b/workshop/content/20-typescript/30-hello-cdk/300-apigw.md
@@ -15,7 +15,7 @@ will be returned back to the user.
 
 ## Install the API Gateway construct library
 
-```console
+```
 npm install @aws-cdk/aws-apigateway
 ```
 
@@ -64,7 +64,7 @@ proxies all requests to an AWS Lambda function.
 
 Let's see what's going to happen when we deploy this:
 
-```console
+```
 cdk diff
 ```
 
@@ -142,7 +142,7 @@ That's nice. This one line of code added 12 new resources to our stack.
 
 Okay, ready to deploy?
 
-```console
+```
 cdk deploy
 ```
 
@@ -167,7 +167,7 @@ If you don't have [curl](https://curl.haxx.se/) installed, you can always use
 your favorite web browser to hit this URL.
 {{% /notice %}}
 
-```console
+```
 curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 ```
 

--- a/workshop/content/20-typescript/40-hit-counter/300-resources.md
+++ b/workshop/content/20-typescript/40-hit-counter/300-resources.md
@@ -11,7 +11,7 @@ Now, let's define the AWS Lambda function and the DynamoDB table in our
 As usual, we first need to install the DynamoDB construct library (we already
 have the Lambda library installed):
 
-```console
+```
 npm install @aws-cdk/aws-dynamodb
 ```
 

--- a/workshop/content/20-typescript/40-hit-counter/400-use.md
+++ b/workshop/content/20-typescript/40-hit-counter/400-use.md
@@ -44,7 +44,7 @@ relayed back in the reverse order all the way to the user.
 
 ## Deploy
 
-```console
+```
 cdk deploy
 ```
 
@@ -62,7 +62,7 @@ the output of the "deploy" command).
 Use `curl` or your web browser to hit your endpoint (we use `-i` to show HTTP
 response fields and status code):
 
-```console
+```
 curl -i https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 ```
 

--- a/workshop/content/20-typescript/40-hit-counter/600-permissions.md
+++ b/workshop/content/20-typescript/40-hit-counter/600-permissions.md
@@ -51,7 +51,7 @@ export class HitCounter extends cdk.Construct {
 
 Save & deploy:
 
-```console
+```
 cdk deploy
 ```
 
@@ -60,7 +60,7 @@ cdk deploy
 Okay, deployment is complete. Let's run our test again (either use `curl` or
 your web browser):
 
-```console
+```
 curl -i https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 ```
 
@@ -159,7 +159,7 @@ export class HitCounter extends cdk.Construct {
 
 You can check what this did using `cdk diff`:
 
-```console
+```
 cdk diff
 ```
 
@@ -195,13 +195,13 @@ Which is exactly what we wanted.
 
 Okay... let's give this another shot:
 
-```console
+```
 cdk deploy
 ```
 
 Then hit your endpoint with `curl` or with your web browser:
 
-```console
+```
 curl -i https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 ```
 

--- a/workshop/content/20-typescript/40-hit-counter/700-test.md
+++ b/workshop/content/20-typescript/40-hit-counter/700-test.md
@@ -8,7 +8,7 @@ weight = 700
 Let's issue a few requests and see if our hit counter works. You can also use
 your web browser to do that:
 
-```console
+```
 curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/hello

--- a/workshop/content/20-typescript/50-table-viewer/200-install.md
+++ b/workshop/content/20-typescript/50-table-viewer/200-install.md
@@ -8,7 +8,7 @@ weight = 200
 Before you can use the table viewer in your application, you'll need to install
 the npm module:
 
-```console
+```
 npm install cdk-dynamo-table-viewer@3.0.2
 ```
 

--- a/workshop/content/20-typescript/50-table-viewer/500-deploy.md
+++ b/workshop/content/20-typescript/50-table-viewer/500-deploy.md
@@ -8,7 +8,7 @@ weight = 500
 Before we deploy, let's take a look at what will happen when we deploy our app
 (this is just the `Resources` section of the output):
 
-```console
+```
 $ cdk diff
 Resources
 [+] AWS::IAM::Role ViewHitCounter/Rendered/ServiceRole ViewHitCounterRenderedServiceRole254DB4EA
@@ -43,7 +43,7 @@ trust  {{% /notice %}}
 
 ### cdk deploy
 
-```console
+```
 $ cdk deploy
 ...
 CdkWorkshopStack.ViewHitCounterViewerEndpointCA1B1E4B = https://mgmshrjxt1.execute-api.us-east-1.amazonaws.com/prod/
@@ -65,7 +65,7 @@ viewer. You should see the values update in real-time.
 
 Use `curl` or your web browser to produce a few hits:
 
-```console
+```
 $ curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/hit1
 $ curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/hit1
 $ curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/hit1

--- a/workshop/content/20-typescript/60-cleanups/_index.md
+++ b/workshop/content/20-typescript/60-cleanups/_index.md
@@ -12,7 +12,7 @@ stack.
 You can either delete the stack through the AWS CloudFormation console or use
 `cdk destroy`:
 
-```console
+```
 cdk destroy
 ```
 

--- a/workshop/content/30-python/20-create-project/100-cdk-init.md
+++ b/workshop/content/30-python/20-create-project/100-cdk-init.md
@@ -7,7 +7,7 @@ weight = 100
 
 Create an empty directory on your system:
 
-```console
+```
 mkdir cdk-workshop && cd cdk-workshop
 ```
 
@@ -15,7 +15,7 @@ mkdir cdk-workshop && cd cdk-workshop
 
 We will use `cdk init` to create a new Python CDK project:
 
-```console
+```
 cdk init sample-app --language python
 ```
 
@@ -23,7 +23,7 @@ Output should look like this (you can safely ignore warnings about
 initialization of a git repository, this probably means you don't have git
 installed, which is fine for this workshop):
 
-```console
+```
 Applying project template sample-app for python
 Initializing a new git repository...
 Executing Creating virtualenv...

--- a/workshop/content/30-python/20-create-project/200-virtualenv.md
+++ b/workshop/content/30-python/20-create-project/200-virtualenv.md
@@ -17,19 +17,19 @@ activate it within your shell.  The generated README file provides all of this
 information but we are calling it out here because it is important.  To
 activate your virtualenv on a Linux or MacOs platform:
 
-```console
+```
 source .env/bin/activate
 ```
 
 One a Windows platform, you would use this:
 
-```console
+```
 .env/Scripts/activate.bat
 ```
 
 Now that the virtual environment is activated, you can safely install the
 required python modules.
 
-```console
+```
 pip install -r requirements.txt
 ```

--- a/workshop/content/30-python/20-create-project/400-synth.md
+++ b/workshop/content/30-python/20-create-project/400-synth.md
@@ -15,7 +15,7 @@ template synthesized from the sample app.  Because our app includes two stacks
 we need to tell the ``cdk synth`` command which stack we want to synthesize.
 You can get a list of available stacks:
 
-```console
+```
 $ cdk ls
 hello-cdk-1
 hello-cdk-2
@@ -24,7 +24,7 @@ $
 
 We can then synthesize one of the stacks:
 
-```console
+```
 $ cdk synth hello-cdk-1
 ```
 

--- a/workshop/content/30-python/20-create-project/500-deploy.md
+++ b/workshop/content/30-python/20-create-project/500-deploy.md
@@ -15,7 +15,7 @@ bucket that is used to store templates and assets during the deployment process.
 You can use the `cdk bootstrap` command to install the bootstrap stack into an
 environment:
 
-```console
+```
 cdk bootstrap
 ```
 
@@ -32,7 +32,7 @@ Hopefully this command finished successfully and we can move on to deploy our ap
 
 Use `cdk deploy` to deploy a CDK app:
 
-```console
+```
 cdk deploy hello-cdk-1
 ```
 

--- a/workshop/content/30-python/30-hello-cdk/100-cleanup.md
+++ b/workshop/content/30-python/30-hello-cdk/100-cleanup.md
@@ -35,7 +35,7 @@ Now, that we modified our stack's contents, we can ask the toolkit to show us
 what will happen if we run `cdk deploy` (the difference between our CDK app and
 what's currently deployed):
 
-```console
+```
 cdk diff hello-cdk-1
 ```
 
@@ -102,7 +102,7 @@ As expected, all of our resources are going to be brutally destroyed.
 
 Run `cdk deploy` and __proceed to the next section__ (no need to wait):
 
-```console
+```
 cdk deploy hello-cdk-1
 ```
 

--- a/workshop/content/30-python/30-hello-cdk/200-lambda.md
+++ b/workshop/content/30-python/30-hello-cdk/200-lambda.md
@@ -46,7 +46,7 @@ Library reference](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-construct
 Okay, let's use `pip install` to install the AWS Lambda
 module and all it's dependencies into our project:
 
-```console
+```
 pip install aws-cdk.aws-lambda
 ```
 
@@ -133,7 +133,7 @@ signature:
 
 Save your code, and let's take a quick look at the diff before we deploy:
 
-```console
+```
 cdk diff hello-cdk-1
 ```
 
@@ -176,7 +176,7 @@ that are used by the toolkit to propagate the location of the handler code.
 
 Let's deploy:
 
-```console
+```
 cdk deploy hello-cdk-1
 ```
 

--- a/workshop/content/30-python/30-hello-cdk/300-apigw.md
+++ b/workshop/content/30-python/30-hello-cdk/300-apigw.md
@@ -15,7 +15,7 @@ will be returned back to the user.
 
 ## Install the API Gateway construct library
 
-```console
+```
 pip install aws-cdk.aws_apigateway
 ```
 
@@ -56,7 +56,7 @@ proxies all requests to an AWS Lambda function.
 
 Let's see what's going to happen when we deploy this:
 
-```console
+```
 cdk diff hello-cdk-1
 ```
 
@@ -139,7 +139,7 @@ That's nice. This one line of code added 12 new resources to our stack.
 
 Okay, ready to deploy?
 
-```console
+```
 cdk deploy hello-cdk-1
 ```
 
@@ -164,7 +164,7 @@ If you don't have [curl](https://curl.haxx.se/) installed, you can always use
 your favorite web browser to hit this URL.
 {{% /notice %}}
 
-```console
+```
 curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 ```
 

--- a/workshop/content/30-python/40-hit-counter/200-handler.md
+++ b/workshop/content/30-python/40-hit-counter/200-handler.md
@@ -8,7 +8,7 @@ weight = 100
 Okay, now let's write the Lambda handler code for our hit counter.  First, we
 will need to install the AWS DynamoDB module.
 
-```console
+```
 pip install aws-cdk.aws_dynamodb
 ```
 

--- a/workshop/content/30-python/40-hit-counter/400-use.md
+++ b/workshop/content/30-python/40-hit-counter/400-use.md
@@ -50,7 +50,7 @@ relayed back in the reverse order all the way to the user.
 
 ## Deploy
 
-```console
+```
 cdk deploy hello-cdk-1
 ```
 
@@ -68,7 +68,7 @@ the output of the "deploy" command).
 Use `curl` or your web browser to hit your endpoint (we use `-i` to show HTTP
 response fields and status code):
 
-```console
+```
 curl -i https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 ```
 

--- a/workshop/content/30-python/40-hit-counter/600-permissions.md
+++ b/workshop/content/30-python/40-hit-counter/600-permissions.md
@@ -48,7 +48,7 @@ class HitCounter(core.Construct):
 
 Save & deploy:
 
-```console
+```
 cdk deploy hello-cdk-1
 ```
 
@@ -57,7 +57,7 @@ cdk deploy hello-cdk-1
 Okay, deployment is complete. Let's run our test again (either use `curl` or
 your web browser):
 
-```console
+```
 curl -i https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 ```
 
@@ -151,7 +151,7 @@ class HitCounter(core.Construct):
 
 You can check what this did using `cdk diff`:
 
-```console
+```
 cdk diff hello-cdk-1
 ```
 
@@ -199,13 +199,13 @@ Which is exactly what we wanted.
 
 Okay... let's give this another shot:
 
-```console
+```
 cdk deploy hello-cdk-1
 ```
 
 Then hit your endpoint with `curl` or with your web browser:
 
-```console
+```
 curl -i https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 ```
 

--- a/workshop/content/30-python/40-hit-counter/700-test.md
+++ b/workshop/content/30-python/40-hit-counter/700-test.md
@@ -8,7 +8,7 @@ weight = 700
 Let's issue a few requests and see if our hit counter works. You can also use
 your web browser to do that:
 
-```console
+```
 curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/
 curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/hello

--- a/workshop/content/30-python/50-table-viewer/200-install.md
+++ b/workshop/content/30-python/50-table-viewer/200-install.md
@@ -8,7 +8,7 @@ weight = 200
 Before you can use the table viewer in your application, you'll need to install
 the python module:
 
-```console
+```
 pip install cdk-dynamo-table-viewer
 ```
 

--- a/workshop/content/30-python/50-table-viewer/500-deploy.md
+++ b/workshop/content/30-python/50-table-viewer/500-deploy.md
@@ -8,7 +8,7 @@ weight = 500
 Before we deploy, let's take a look at what will happen when we deploy our app
 (this is just the `Resources` section of the output):
 
-```console
+```
 $ cdk diff hello-cdk-1
 Resources
 [+] AWS::IAM::Role ViewHitCounter/Rendered/ServiceRole ViewHitCounterRenderedServiceRole254DB4EA 
@@ -43,7 +43,7 @@ trust  {{% /notice %}}
 
 ### cdk deploy
 
-```console
+```
 $ cdk deploy hello-cdk-1
 ...
 hello-cdk-1.ViewHitCounterViewerEndpointCA1B1E4B = https://6i4udz9wb2.execute-api.us-east-2.amazonaws.com/prod/
@@ -65,7 +65,7 @@ viewer. You should see the values update in real-time.
 
 Use `curl` or your web browser to produce a few hits:
 
-```console
+```
 $ curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/hit1
 $ curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/hit1
 $ curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/hit1

--- a/workshop/content/30-python/60-cleanups/_index.md
+++ b/workshop/content/30-python/60-cleanups/_index.md
@@ -12,7 +12,7 @@ stack.
 You can either delete the stack through the AWS CloudFormation console or use
 `cdk destroy`:
 
-```console
+```
 cdk destroy hello-cdk-1
 ```
 


### PR DESCRIPTION
"console" syntax coloring is the same as shell. This causes random words that happen to be shell keywords to be colorized in the text.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
