### PR TITLE
Removing version pinned table-viewer, no longer needed

### DIFF
--- a/workshop/content/20-typescript/50-table-viewer/200-install.md
+++ b/workshop/content/20-typescript/50-table-viewer/200-install.md
@@ -9,7 +9,7 @@ Before you can use the table viewer in your application, you'll need to install
 the npm module:
 
 ```
-npm install cdk-dynamo-table-viewer@3.0.2
+npm install cdk-dynamo-table-viewer
 ```
 
 {{% notice info %}}
@@ -24,7 +24,7 @@ in use.
 Output should look like this:
 
 ```
-+ cdk-dynamo-table-viewer@3.0.2
++ cdk-dynamo-table-viewer
 added 30 packages from 5 contributors and audited 3663 packages in 7.987s
 found 0 vulnerabilities
 ```


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes #45 

Removing the version pinned table-viewer. It's was pinned to 3.0.2 which requires old peer dependencies. 

`requires a peer of @aws-cdk/aws-apigateway@^0.38.0` 

This is no longer needed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
