### PR TITLE
Fixing indention

### DIFF
--- a/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
+++ b/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
@@ -11,12 +11,13 @@ We'll start with the AWS Lambda handler code.
    and `lib`).
 2. Add a file called `lambda/hello.js` with the following contents:
 
+---
 ```js
 exports.handler = async function(event) {
-  console.log('request:', JSON.stringify(event, undefined, 2));
+  console.log("request:", JSON.stringify(event, undefined, 2));
   return {
     statusCode: 200,
-    headers: { 'Content-Type': 'text/plain' },
+    headers: { "Content-Type": "text/plain" },
     body: `Hello, CDK! You've hit ${event.path}\n`
   };
 };


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes #79  <!-- Please create a new issue if none exists yet -->

Hugo renders the JS code in the markdown incorrectly if it's present after a list. I fixed this by adding a horizontal ruler as a workaround:

<img width="928" alt="image" src="https://user-images.githubusercontent.com/4455323/66956023-e1aab380-f063-11e9-83ca-c9768b4070dd.png">
 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
