### PR TITLE
fix: changed highlighted line in "Exposing our hit counter table" TS Workshop page

### DIFF
--- a/workshop/content/20-typescript/50-table-viewer/400-expose-table.md
+++ b/workshop/content/20-typescript/50-table-viewer/400-expose-table.md
@@ -7,7 +7,7 @@ weight = 400
 
 Edit `hitcounter.ts` and modify it as such `table` is exposed as a public property.
 
-{{<highlight ts "hl_lines=14-15 24">}}
+{{<highlight ts "hl_lines=14-15 26">}}
 import cdk = require('@aws-cdk/core');
 import lambda = require('@aws-cdk/aws-lambda');
 import dynamodb = require('@aws-cdk/aws-dynamodb');


### PR DESCRIPTION
The wrong line is highlighted

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
