### PR TITLE
docs: Update cdk.json content

### DIFF
--- a/workshop/content/20-typescript/20-create-project/300-structure.md
+++ b/workshop/content/20-typescript/20-create-project/300-structure.md
@@ -23,7 +23,7 @@ You'll see something like this:
   name of your app, version, dependencies and build scripts like "watch" and
   "build" (`package-lock.json` is maintained by npm)
 * `cdk.json` tells the toolkit how to run your app. In our case it will be
-  `"node bin/cdk-workshop.js"`
+  `"npx ts-node bin/cdk-workshop.ts"`
 * `tsconfig.json` your project's [typescript
   configuration](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html)
 * `.gitignore` and `.npmignore` tell git and npm which files to include/exclude


### PR DESCRIPTION
Contents incorrectly shows that 'node' will be used to run the JavaScript version of the app.

The current iteration of this workshops uses 'npx' to run the TypeScript version of the app. So this commit updates the content to the actual content of cdk.json.