### PR TITLE
docs: Minor grammar fix

### DIFF
--- a/workshop/content/20-typescript/20-create-project/300-structure.md
+++ b/workshop/content/20-typescript/20-create-project/300-structure.md
@@ -43,7 +43,7 @@ const app = new cdk.App();
 new CdkWorkshopStack(app, 'CdkWorkshopStack');
 ```
 
-This code loads and instantiate the `CdkWorkshopStack` class from the
+This code loads and instantiates the `CdkWorkshopStack` class from the
 `lib/cdk-workshop-stack.ts` file. We won't need to look at this file anymore.
 
 ## The main stack

--- a/workshop/content/50-java/20-create-project/300-structure.md
+++ b/workshop/content/50-java/20-create-project/300-structure.md
@@ -45,7 +45,7 @@ public final class CdkWorkshopApp {
 }
 ```
 
-This code loads and instantiate the `CdkWorkshopStack` class from the
+This code loads and instantiates the `CdkWorkshopStack` class from the
 `~/CdkWorkshopStack.java` file. We won't need to look at this file anymore.
 
 ## The main stack


### PR DESCRIPTION
The word 'instantiate' should have a 's' on the end to be grammatically correct in this context.  It looks like it has already been corrected for the Python and .NET versions of the workshop.