### PR TITLE
docs: Fix markdown italics

### DIFF
--- a/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
+++ b/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
@@ -125,8 +125,8 @@ signature:
    It's an ID that has to be unique amongst construct within the same scope. The
    CDK uses this identity to calculate the CloudFormation [Logical
    ID](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html)
-   for each resource defined within this scope. _To read more about IDs in the
-   CDK, see the [CDK user manual](https://docs.aws.amazon.com/cdk/latest/guide/identifiers.html#identifiers_logical_ids)._
+   for each resource defined within this scope. *To read more about IDs in the
+   CDK, see the* [CDK user manual](https://docs.aws.amazon.com/cdk/latest/guide/identifiers.html#identifiers_logical_ids).
 3. __`props`__: the last (sometimes optional) argument is always a set of
    initialization properties. Those are specific to each construct. For example,
    the `lambda.Function` construct accepts properties like `runtime`, `code` and

--- a/workshop/content/20-typescript/40-hit-counter/300-resources.md
+++ b/workshop/content/20-typescript/40-hit-counter/300-resources.md
@@ -77,6 +77,6 @@ The `functionName` and `tableName` properties are values that only resolve when
 we deploy our stack (notice that we haven't configured these physical names when
 we defined the table/function, only logical IDs). This means that if you print
 their values during synthesis, you will get a "TOKEN", which is how the CDK
-represents these late-bound values. You should treat tokens as _opaque strings_.
+represents these late-bound values. You should treat tokens as *opaque strings*.
 This means you can concatenate them together for example, but don't be tempted
 to parse them in your code.

--- a/workshop/content/30-python/30-hello-cdk/200-lambda.md
+++ b/workshop/content/30-python/30-hello-cdk/200-lambda.md
@@ -122,8 +122,8 @@ signature:
    It's an ID that has to be unique amongst construct within the same scope. The
    CDK uses this identity to calculate the CloudFormation [Logical
    ID](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html)
-   for each resource defined within this scope. _To read more about IDs in the
-   CDK, see the [CDK user manual](https://docs.aws.amazon.com/cdk/latest/guide/identifiers.html#identifiers_logical_ids)._
+   for each resource defined within this scope. *To read more about IDs in the
+   CDK, see the* [CDK user manual](https://docs.aws.amazon.com/cdk/latest/guide/identifiers.html#identifiers_logical_ids).
 3. __`kwargs`__: the last (sometimes optional) arguments is always a set of
    initialization arguments. Those are specific to each construct. For example,
    the `lambda.Function` construct accepts arguments like `runtime`, `code` and

--- a/workshop/content/30-python/40-hit-counter/300-resources.md
+++ b/workshop/content/30-python/40-hit-counter/300-resources.md
@@ -57,6 +57,6 @@ The `function_name` and `table_name` properties are values that only resolve
 when we deploy our stack (notice that we haven't configured these physical
 names when we defined the table/function, only logical IDs). This means that if
 you print their values during synthesis, you will get a "TOKEN", which is how
-the CDK represents these late-bound values. You should treat tokens as _opaque
-strings_.  This means you can concatenate them together for example, but don't
+the CDK represents these late-bound values. You should treat tokens as *opaque
+strings*.  This means you can concatenate them together for example, but don't
 be tempted to parse them in your code.

--- a/workshop/content/40-dotnet/30-hello-cdk/200-lambda.md
+++ b/workshop/content/40-dotnet/30-hello-cdk/200-lambda.md
@@ -119,8 +119,8 @@ signature:
    It's an ID that has to be unique amongst construct within the same scope. The
    CDK uses this identity to calculate the CloudFormation [Logical
    ID](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html)
-   for each resource defined within this scope. _To read more about IDs in the
-   CDK, see the [CDK user manual](https://docs.aws.amazon.com/cdk/latest/guide/identifiers.html#identifiers_logical_ids)._
+   for each resource defined within this scope. *To read more about IDs in the
+   CDK, see the* [CDK user manual](https://docs.aws.amazon.com/cdk/latest/guide/identifiers.html#identifiers_logical_ids).
 3. __`props`__: the last (sometimes optional) argument is always a set of
    initialization properties. Those are specific to each construct. For example,
    the `lambda.Function` construct accepts properties like `runtime`, `code` and

--- a/workshop/content/40-dotnet/40-hit-counter/300-resources.md
+++ b/workshop/content/40-dotnet/40-hit-counter/300-resources.md
@@ -79,6 +79,6 @@ The `FunctionName` and `TableName` properties are values that only resolve when
 we deploy our stack (notice that we haven't configured these physical names when
 we defined the table/function, only logical IDs). This means that if you print
 their values during synthesis, you will get a "TOKEN", which is how the CDK
-represents these late-bound values. You should treat tokens as _opaque strings_.
+represents these late-bound values. You should treat tokens as *opaque strings*.
 This means you can concatenate them together for example, but don't be tempted
 to parse them in your code.

--- a/workshop/content/50-java/30-hello-cdk/200-lambda.md
+++ b/workshop/content/50-java/30-hello-cdk/200-lambda.md
@@ -143,8 +143,8 @@ signature:
    It's an ID that has to be unique amongst construct within the same scope. The
    CDK uses this identity to calculate the CloudFormation [Logical
    ID](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html)
-   for each resource defined within this scope. _To read more about IDs in the
-   CDK, see the [CDK user manual](https://docs.aws.amazon.com/cdk/latest/guide/identifiers.html#identifiers_logical_ids)._
+   for each resource defined within this scope. *To read more about IDs in the
+   CDK, see the* [CDK user manual](https://docs.aws.amazon.com/cdk/latest/guide/identifiers.html#identifiers_logical_ids).
 3. __`props`__: the last (sometimes optional) argument is always a set of
    initialization properties. Those are specific to each construct. For example,
    the `lambda.Function` construct accepts properties like `runtime`, `code` and

--- a/workshop/content/50-java/40-hit-counter/300-resources.md
+++ b/workshop/content/50-java/40-hit-counter/300-resources.md
@@ -114,6 +114,6 @@ The `FunctionName` and `TableName` properties are values that only resolve when
 we deploy our stack (notice that we haven't configured these physical names when
 we defined the table/function, only logical IDs). This means that if you print
 their values during synthesis, you will get a "TOKEN", which is how the CDK
-represents these late-bound values. You should treat tokens as _opaque strings_.
+represents these late-bound values. You should treat tokens as *opaque strings*.
 This means you can concatenate them together for example, but don't be tempted
 to parse them in your code.


### PR DESCRIPTION
Converted markdown italics from `_underscore_` to the more standard `*single-asterisk*` format that is used in all other locations in the code.

Also attempted to fix the issue in the `200-lambda.md` files where the italics surrounding the "To read more about IDs..." text+link were not being honored when the markdown was being converted to HTML.  This resulted in the underscore characters showing on the cdkworkshop.com website and the inner text _not_ being italicized. My fix was to terminate the italicization before the link.