### PR TITLE
docs: Correct explanation of type for 'Downstream' property

### DIFF
--- a/workshop/content/20-typescript/40-hit-counter/100-api.md
+++ b/workshop/content/20-typescript/40-hit-counter/100-api.md
@@ -33,7 +33,7 @@ Save the file. Oops, an error! No worries, we'll be using `props` shortly.
 * As usual, constructor arguments are `scope`, `id` and `props`, and we
   propagate them to the `cdk.Construct` base class.
 * The `props` argument is of type `HitCounterProps` which includes a single
-  property `downstream` of type `lambda.Function`. This is where we are going to "plug in" the
+  property `downstream` of type `lambda.IFunction`. This is where we are going to "plug in" the
   Lambda function we created in the previous chapter so it can be hit-counted.
 
 ----

--- a/workshop/content/40-dotnet/40-hit-counter/100-api.md
+++ b/workshop/content/40-dotnet/40-hit-counter/100-api.md
@@ -38,7 +38,7 @@ Save the file.
 * As usual, constructor arguments are `scope`, `id` and `props`, and we
   propagate them to the `Construct` base class.
 * The `props` argument is of type `HitCounterProps` which includes a single
-  property `Downstream` of type `Function`. This is where we are going to "plug in" the
+  property `Downstream` of type `IFunction`. This is where we are going to "plug in" the
   Lambda function we created in the previous chapter so it can be hit-counted.
 
 ----


### PR DESCRIPTION
In the "What's going on here?" section, the explanation of the type for the `Downstream` property is incorrect.  The letter "I" (for interface) appears to have been dropped.

I've corrected it for the TypeScript and .NET documentation.

Fixes # 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
