### PR TITLE
docs: Make formatting consistent with later versions of code

### DIFF
--- a/workshop/content/20-typescript/40-hit-counter/300-resources.md
+++ b/workshop/content/20-typescript/40-hit-counter/300-resources.md
@@ -45,7 +45,10 @@ export class HitCounter extends cdk.Construct {
       super(scope, id);
 
     const table = new dynamodb.Table(this, 'Hits', {
-        partitionKey: { name: 'path', type: dynamodb.AttributeType.STRING }
+        partitionKey: {
+            name: 'path',
+            type: dynamodb.AttributeType.STRING
+        }
     });
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {


### PR DESCRIPTION
The formatting of `partitionKey` in 300-resources.md is inconsistent with the way that same code is presented in 400-expose-table.md.  This makes it difficult to find the code when you are asked to place a new entry after that code block in 400-expose-table.md.

I've expanded the hash across multiple line to maintain formatting consistency.

Fixes # 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
