### PR TITLE
doc: update the cdk toolkit version

### DIFF
--- a/workshop/data/common.toml
+++ b/workshop/data/common.toml
@@ -1,2 +1,2 @@
 [cdk]
-version = "0.37.0"
+version = "1.21.1 (build 842cc5f)"


### PR DESCRIPTION
update the cdk cli's version number to the latest one out there, currently

( maybe this version string can get dynamically updated by a lambda, whenever there is a new version out on npm... :-) )

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
