### PR TITLE
fix: remove outdated blurb about error

### DIFF
--- a/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
+++ b/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
@@ -93,8 +93,6 @@ export class CdkWorkshopStack extends cdk.Stack {
 
 A few things to notice:
 
-- Once you save *cdk-workshop-stack.ts*, you should see an error message in the
-  `npm run watch` window that hello is declared but never use. Cool huh?
 - Our function uses NodeJS 8.10 runtime
 - The handler code is loaded from the `lambda` directory which we created
   earlier. Path is relative to where you execute `cdk` from, which is the


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->
Tsc watch window no longer throws error at indicated point. Removing comment about error.

Fixes #92  <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
