### PR TITLE
fix: minor typo in path at `python/create_project/structure`

### DIFF
--- a/workshop/content/30-python/20-create-project/300-structure.md
+++ b/workshop/content/30-python/20-create-project/300-structure.md
@@ -47,7 +47,7 @@ app.synth()
 ```
 
 This code loads and instantiates an instance of the `CdkWorkshopStack` class from 
-`cdkworshop/cdk_orkshop_stack.py` file. We won't need to look at this file anymore.
+`cdkworshop/cdk_workshop_stack.py` file. We won't need to look at this file anymore.
 
 ## The main stack
 


### PR DESCRIPTION
Just fixing a typo in `/30-python/20-create-project/300-structure`

Fixes # couldn't bring myself to open a "bug" for this :)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
