### PR TITLE
fix: Updating node version for typescript lambda example

### DIFF
--- a/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
+++ b/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
@@ -93,7 +93,7 @@ export class CdkWorkshopStack extends cdk.Stack {
 
 A few things to notice:
 
-- Our function uses NodeJS 8.10 runtime
+- Our function uses NodeJS 10.x runtime
 - The handler code is loaded from the `lambda` directory which we created
   earlier. Path is relative to where you execute `cdk` from, which is the
   project's root directory


### PR DESCRIPTION
Nodejs8.10 is no longer supported for creating or updating AWS Lambda functions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
