### PR TITLE
fix: misleading claim on dynamodb tables

### DIFF
--- a/workshop/content/20-typescript/40-hit-counter/300-resources.md
+++ b/workshop/content/20-typescript/40-hit-counter/300-resources.md
@@ -65,8 +65,7 @@ export class HitCounter extends cdk.Construct {
 
 This code is hopefully quite easy to understand:
 
- * We defined a DynamoDB table with `path` as the partition key (every DynamoDB
-   table must have a single partition key).
+ * We defined a DynamoDB table with `path` as the partition key.
  * We defined a Lambda function which is bound to the `lambda/hitcounter.handler` code.
  * We __wired__ the Lambda's environment variables to the `functionName` and `tableName`
    of our resources.


### PR DESCRIPTION
This isn't true: " (every DynamoDB
   table must have a single partition key)"

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
