### PR TITLE
fix: Python classes should be surrounded by two blank lines

### DIFF
--- a/workshop/content/30-python/20-create-project/300-structure.md
+++ b/workshop/content/30-python/20-create-project/300-structure.md
@@ -15,7 +15,7 @@ You'll see something like this:
 
 ![](./structure.png)
 
-* .env - The python virtual envirnment information discussed in the previous section.
+* .env - The python virtual environment information discussed in the previous section.
 * cdkworkshop — A Python module directory.
   * cdkworkshop.egg-info - Folder that contains build information relevant for the packaging on the project
   * cdkworkshop_stack.py—A custom CDK stack construct for use in your CDK application.
@@ -62,6 +62,7 @@ from aws_cdk import (
     aws_sns_subscriptions as subs,
     core
 )
+
 
 class CdkWorkshopStack(core.Stack):
 

--- a/workshop/content/30-python/40-hit-counter/100-api.md
+++ b/workshop/content/30-python/40-hit-counter/100-api.md
@@ -13,6 +13,7 @@ from aws_cdk import (
     core
 )
 
+
 class HitCounter(core.Construct):
 
     def __init__(self, scope: core.Construct, id: str, downstream: _lambda.IFunction, **kwargs):

--- a/workshop/content/30-python/40-hit-counter/300-resources.md
+++ b/workshop/content/30-python/40-hit-counter/300-resources.md
@@ -15,6 +15,7 @@ from aws_cdk import (
     core,
 )
 
+
 class HitCounter(core.Construct):
 
     @property

--- a/workshop/content/30-python/40-hit-counter/600-permissions.md
+++ b/workshop/content/30-python/40-hit-counter/600-permissions.md
@@ -16,6 +16,7 @@ from aws_cdk import (
     core,
 )
 
+
 class HitCounter(core.Construct):
 
     @property
@@ -117,6 +118,7 @@ from aws_cdk import (
     aws_dynamodb as ddb,
     core,
 )
+
 
 class HitCounter(core.Construct):
 

--- a/workshop/content/30-python/50-table-viewer/400-expose-table.md
+++ b/workshop/content/30-python/50-table-viewer/400-expose-table.md
@@ -14,6 +14,7 @@ from aws_cdk import (
     core,
 )
 
+
 class HitCounter(core.Construct):
 
     @property


### PR DESCRIPTION
Classes should be surrounded by 2 blank lines according to PEP8. The code snippets sometimes do this, and sometimes don't. I noticed that is an issue in the aws-cdk templates, I've raised https://github.com/aws/aws-cdk/pull/8936 for that.
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
