### PR TITLE
fix: typo/grammar fixes in Python doco

### DIFF
--- a/workshop/content/30-python/20-create-project/200-virtualenv.md
+++ b/workshop/content/30-python/20-create-project/200-virtualenv.md
@@ -6,7 +6,7 @@ weight = 200
 ## Activating the Virtualenv
 
 The init script we ran in the last step created a bunch of code to help get us
-started but it also created a virtual environment within our directory.  If you
+started, but it also created a virtual environment within our directory.  If you
 haven't used virtualenv before, you can find out more
 [here](https://docs.python.org/3/tutorial/venv.html) but the bottom line is
 that they allow you have a self-contained, isolated environment to run Python
@@ -14,7 +14,7 @@ and install arbitrary packages without polluting your system Python.
 
 To take advantage of the virtual environment that was created, you have to
 activate it within your shell.  The generated README file provides all of this
-information but we are calling it out here because it is important.  To
+information, but we are calling it out here because it is important.  To
 activate your virtualenv on a Linux or MacOs platform:
 
 ```

--- a/workshop/content/30-python/20-create-project/300-structure.md
+++ b/workshop/content/30-python/20-create-project/300-structure.md
@@ -25,7 +25,7 @@ You'll see something like this:
 * app.py — The “main” for this sample application.
 * cdk.json — A configuration file for CDK that defines what executable CDK should run to generate the CDK construct tree.
 * README.md — The introductory README for this project.
-* requirements.txt—This file is used by pip to install all of the dependencies for your application. In this case, it contains only -e . This tells pip to install the requirements specified in setup.py. It also tells pip to run python setup.py develop to install the code in the cdk-workshop module so that it can be edited in place.
+* requirements.txt — Used by pip to install all dependencies for your application. In this case, it contains only -e . This tells pip to install the requirements specified in setup.py. It also tells pip to run python setup.py develop to install the code in the cdk-workshop module so that it can be edited in place.
 * setup.py — Defines how this Python package would be constructed and what the dependencies are.
 
 ## Your app's entry point
@@ -83,7 +83,7 @@ class CdkWorkshopStack(core.Stack):
 As you can see, our app was created with two instances of our sample CDK stack
 (`CdkWorkshopStack`).
 
-The stacks includes:
+The stacks include:
 
 - SQS Queue (`sqs.Queue`)
 - SNS Topic (`sns.Topic`)

--- a/workshop/content/30-python/20-create-project/500-deploy.md
+++ b/workshop/content/30-python/20-create-project/500-deploy.md
@@ -56,7 +56,7 @@ Do you wish to deploy these changes (y/n)?
 ```
 
 This is warning you that deploying the app entails some risk.  Since we need to
-allow the topic to send messages to the queue and we are also creating an IAM
+allow the topic to send messages to the queue, and we are also creating an IAM
 User and granting access to the new Buckets, enter **y** to deploy the stack
 and create the resources.
 

--- a/workshop/content/30-python/30-hello-cdk/_index.md
+++ b/workshop/content/30-python/30-hello-cdk/_index.md
@@ -10,7 +10,7 @@ In this chapter, we will finally write some CDK code. Instead of the SNS/SQS
 code that we have in our app now, we'll add a Lambda function with an API
 Gateway endpoint in front of it.
 
-Users will be able to hit any URL in the endpoint and they'll receive a
+Users will be able to hit any URL in the endpoint, and they'll receive a
 heartwarming greeting from our function.
 
 ![](/images/hello-arch.png)

--- a/workshop/content/30-python/40-hit-counter/100-api.md
+++ b/workshop/content/30-python/40-hit-counter/100-api.md
@@ -30,8 +30,8 @@ Save the file.
   propagate them to the `cdk.Construct` base class.
 * The `HitCounter` class also takes one explicit keyword parameter `downstream`
   of type `lambda.IFunction`. This is where we are going to "plug in" the Lambda
-  function we created in the previous chapter so it can be hit-counted.
+  function we created in the previous chapter, so it can be hit-counted.
 
 ----
 
-Next, are are going to write the handler code of our hit counter.
+Next, we are going to write the handler code of our hit counter.

--- a/workshop/content/30-python/40-hit-counter/200-handler.md
+++ b/workshop/content/30-python/40-hit-counter/200-handler.md
@@ -5,7 +5,7 @@ weight = 100
 
 ## Hit counter Lambda handler
 
-Okay, now let's write the Lambda handler code for our hit counter.  First, we
+Okay, now let's write the Lambda handler code for our hit counter. First, we
 will need to install the AWS DynamoDB module.
 
 ```

--- a/workshop/content/30-python/50-table-viewer/100-discovery.md
+++ b/workshop/content/30-python/50-table-viewer/100-discovery.md
@@ -9,7 +9,7 @@ Browse to the [cdk-dynamo-table-viewer
 page](https://pypi.org/project/cdk-dynamo-table-viewer/) on pypi.org and
 read the module documentation.
 
-There is some documentation about how to use the table viewer in the README but it is all focused on TypeScript rather than Python.  So, we will walk through the process of using a third-party construct in Python.
+There is some documentation about how to use the table viewer in the README, but it is all focused on TypeScript rather than Python.  So, we will walk through the process of using a third-party construct in Python.
 
 {{% notice warning %}}
 As mentioned in the README page of this library, it is not intended for production use. Namely because

--- a/workshop/content/30-python/50-table-viewer/500-deploy.md
+++ b/workshop/content/30-python/50-table-viewer/500-deploy.md
@@ -35,7 +35,7 @@ function, permissions, outputs, all sorts of goodies.
 allow you to add complex capabilities to your apps with minimum effort. However,
 you must understand that with great power comes great responsibility. Constructs
 can add IAM permissions, expose data to the public or cause your application not
-to function. We are working on providing you tools for protecting your app, and
+to function. We are working on providing you tools for protection of your app, and
 identifying potential security issues with your stacks, but it is your
 responsibility to understand how certain constructs that you use impact your
 application, and to make sure you only use construct libraries from vendors you


### PR DESCRIPTION
Fixes a bunch of small typos and grammar issues

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
