### PR TITLE
fix: TypeScript missing lambda import

### DIFF
--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -19,6 +19,7 @@ same level as `bin` and `lib` and then create a file called `hitcounter.test.ts`
 import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
 import cdk = require('@aws-cdk/core');
 import * as lambda from '@aws-cdk/aws-lambda';
+
 import { HitCounter }  from '../lib/hitcounter';
 
 test('DynamoDB Table Created', () => {

--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -18,6 +18,7 @@ same level as `bin` and `lib` and then create a file called `hitcounter.test.ts`
 ```typescript
 import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
 import cdk = require('@aws-cdk/core');
+import * as lambda from '@aws-cdk/aws-lambda';
 import { HitCounter }  from '../lib/hitcounter';
 
 test('DynamoDB Table Created', () => {


### PR DESCRIPTION
Adding lambda import in typescript/1000-assertion-test-100.md

Fixes #145 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
