### PR TITLE
chore: update language 100-cdk-init.md

### DIFF
--- a/workshop/content/40-dotnet/20-create-project/100-cdk-init.md
+++ b/workshop/content/40-dotnet/20-create-project/100-cdk-init.md
@@ -13,7 +13,7 @@ mkdir cdk-workshop && cd cdk-workshop
 
 ## cdk init
 
-We will use `cdk init` to create a new TypeScript CDK project:
+We will use `cdk init` to create a new C# CDK project:
 
 ```
 cdk init sample-app --language csharp


### PR DESCRIPTION
.NET "Create project directory" said "We will use cdk init to create a new TypeScript CDK project:". Changed to "We will use cdk init to create a new C# CDK project:"

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
