### PR TITLE
fix(net): update .NET prereq page for current minimum of .NETCore3.1

### DIFF
--- a/workshop/content/15-prerequisites/700-dotnet.md
+++ b/workshop/content/15-prerequisites/700-dotnet.md
@@ -4,9 +4,9 @@ weight = 700
 +++
 
 If you are planning on using the .NET Workshop, you obviously will need to
-have the .NET Core SDK installed.  Specifically, you will need version 3.0 or later.
+have the .NET Core SDK installed.  Specifically, you will need version 3.1 or later.
 You can find information about downloading and installing .NET Core SDK
 [here](https://dotnet.microsoft.com/download).
 
 We will be using the .NET Core CLI for this project, so if you are not familiar, 
-please take a look at their [documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x).
+please take a look at their [documentation](https://docs.microsoft.com/en-us/dotnet/core/tools).


### PR DESCRIPTION
Update to reflect .NET Core 3.1 is the base version needed.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
