### PR TITLE
fix: highlight proper lines in code example

### DIFF
--- a/workshop/content/20-typescript/30-hello-cdk/300-apigw.md
+++ b/workshop/content/20-typescript/30-hello-cdk/300-apigw.md
@@ -32,7 +32,7 @@ in use.
 
 Going back to `lib/cdk-workshop-stack.ts`, let's define an API endpoint and associate it with our Lambda function:
 
-{{<highlight ts "hl_lines=3 15-18">}}
+{{<highlight ts "hl_lines=3 16-19">}}
 import * as cdk from '@aws-cdk/core';
 import * as lambda from '@aws-cdk/aws-lambda';
 import * as apigw from '@aws-cdk/aws-apigateway';


### PR DESCRIPTION
The lines to be highlighted were off by one. This shifts the group of highlighted lines down by one.