### PR TITLE
fix: make the main workshop TS code compile

### DIFF
--- a/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
@@ -4,7 +4,7 @@ import * as apigw from '@aws-cdk/aws-apigateway';
 import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 
-class CdkWorkshopStack extends cdk.Stack {
+export class CdkWorkshopStack extends cdk.Stack {
   constructor(scope: cdk.App, is: string, props?: cdk.StackProps) {
     super(scope, is, props);
 


### PR DESCRIPTION
Without exporting the CdkWorkshopStack class,
`npm run build` fails with:

```
lib/cdk-workshop-stack.ts(7,7): error TS6196: 'CdkWorkshopStack' is declared but never used.
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
