### PR TITLE
fix: virtualenv directory `.env` to `.venv` for python workshop

### DIFF
--- a/workshop/content/30-python/20-create-project/100-cdk-init.md
+++ b/workshop/content/30-python/20-create-project/100-cdk-init.md
@@ -36,7 +36,7 @@ which contains an Amazon SQS queue that is subscribed to an Amazon SNS topic.
 The `cdk.json` file tells the CDK Toolkit how to execute your app.
 
 This project is set up like a standard Python project.  The initialization process also creates
-a virtualenv within this project, stored under the .env directory.  To create the virtualenv
+a virtualenv within this project, stored under the .venv directory.  To create the virtualenv
 it assumes that there is a `python3` executable in your path with access to the `venv` package.
 If for any reason the automatic creation of the virtualenv fails, you can create the virtualenv
 manually once the init process completes.
@@ -44,20 +44,20 @@ manually once the init process completes.
 To manually create a virtualenv on MacOS and Linux:
 
 ```
-$ python3 -m venv .env
+$ python3 -m venv .venv
 ```
 
 After the init process completes and the virtualenv is created, you can use the following
 step to activate your virtualenv.
 
 ```
-$ source .env/bin/activate
+$ source .venv/bin/activate
 ```
 
 If you are a Windows platform, you would activate the virtualenv like this:
 
 ```
-% .env\Scripts\activate.bat
+% .venv\Scripts\activate.bat
 ```
 
 Once the virtualenv is activated, you can install the required dependencies.

--- a/workshop/content/30-python/20-create-project/200-virtualenv.md
+++ b/workshop/content/30-python/20-create-project/200-virtualenv.md
@@ -18,13 +18,13 @@ information but we are calling it out here because it is important.  To
 activate your virtualenv on a Linux or MacOs platform:
 
 ```
-source .env/bin/activate
+source .venv/bin/activate
 ```
 
 One a Windows platform, you would use this:
 
 ```
-.env\Scripts\activate.bat
+.venv\Scripts\activate.bat
 ```
 
 Now that the virtual environment is activated, you can safely install the

--- a/workshop/content/30-python/20-create-project/300-structure.md
+++ b/workshop/content/30-python/20-create-project/300-structure.md
@@ -15,7 +15,7 @@ You'll see something like this:
 
 ![](./structure.png)
 
-* .env - The python virtual envirnment information discussed in the previous section.
+* .nenv - The python virtual envirnment information discussed in the previous section.
 * cdkworkshop — A Python module directory.
   * cdkworkshop.egg-info - Folder that contains build information relevant for the packaging on the project
   * cdkworkshop_stack.py—A custom CDK stack construct for use in your CDK application.

--- a/workshop/content/30-python/20-create-project/300-structure.md
+++ b/workshop/content/30-python/20-create-project/300-structure.md
@@ -15,7 +15,7 @@ You'll see something like this:
 
 ![](./structure.png)
 
-* .nenv - The python virtual envirnment information discussed in the previous section.
+* .venv - The python virtual envirnment information discussed in the previous section.
 * cdkworkshop — A Python module directory.
   * cdkworkshop.egg-info - Folder that contains build information relevant for the packaging on the project
   * cdkworkshop_stack.py—A custom CDK stack construct for use in your CDK application.


### PR DESCRIPTION
related to: https://github.com/aws/aws-cdk/issues/9134

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
