### PR TITLE
fix: java hitcounter file type typo

### DIFF
--- a/workshop/content/50-java/40-hit-counter/600-permissions.md
+++ b/workshop/content/50-java/40-hit-counter/600-permissions.md
@@ -136,7 +136,7 @@ But, we must also give our hit counter permissions to invoke the downstream lamb
 
 ## Grant invoke permissions
 
-Add the highlighted lines to `src/CdkWorkshop/HitCounter.cs`:
+Add the highlighted lines to `src/CdkWorkshop/HitCounter.java`:
 
 {{<highlight java "hl_lines=43-44">}}
 package com.myorg;


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->
There was a file called `HitCounter.java` and it was being referenced in the docs as `HitCounter.cs`.
This PR just changes the file type to the appropriate `.java`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
