### PR TITLE
fix: TS: changed `inline` to `fromInline`

### DIFF
--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -97,7 +97,7 @@ test('Lambda Has Environment Variables', () => {
     downstream:  new lambda.Function(stack, 'TestFunction', {
       runtime: lambda.Runtime.NODEJS_10_X,
       handler: 'lambda.handler',
-      code: lambda.Code.inline('test')
+      code: lambda.Code.fromInline('test')
     })
   });
   // THEN
@@ -179,7 +179,7 @@ test('Lambda Has Environment Variables', () => {
     downstream:  new lambda.Function(stack, 'TestFunction', {
       runtime: lambda.Runtime.NODEJS_10_X,
       handler: 'lambda.handler',
-      code: lambda.Code.inline('test')
+      code: lambda.Code.fromInline('test')
     })
   });
   // THEN
@@ -236,7 +236,7 @@ test('DynamoDB Table Created With Encryption', () => {
     downstream:  new lambda.Function(stack, 'TestFunction', {
       runtime: lambda.Runtime.NODEJS_10_X,
       handler: 'lambda.handler',
-      code: lambda.Code.inline('test')
+      code: lambda.Code.fromInline('test')
     })
   });
   // THEN


### PR DESCRIPTION
`inline` method is deprecated.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
