### PR TITLE
fix: format of "Variables:" was incorrect

### DIFF
--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -104,8 +104,12 @@ test('Lambda Has Environment Variables', () => {
   expectCDK(stack).to(haveResource("AWS::Lambda::Function", {
     Environment: {
       Variables: {
-        DOWNSTREAM_FUNCTION_NAME: "TestFunction",
-        HITS_TABLE_NAME: "MyTestConstructHits"
+        DOWNSTREAM_FUNCTION_NAME: {
+          Ref: "TestFunctionXXXXX",
+        },
+        HITS_TABLE_NAME: {
+          Ref: "MyTestConstructHitsXXXXX",
+        }
       }
     }
   }));


### PR DESCRIPTION
With the correct format, it should be `{ Ref: "TestFunctionXXXXX" }` instead of `"TestFunctionXXXXX"`.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
