### PR TITLE
fix: replaced deprecated method call

### DIFF
--- a/code/python/main-workshop/cdk-workshop/cdk-workshop_stack.py
+++ b/code/python/main-workshop/cdk-workshop/cdk-workshop_stack.py
@@ -15,7 +15,7 @@ class CdkWorkshopStack(core.Stack):
         my_lambda = _lambda.Function(
             self, 'HelloHandler',
             runtime=_lambda.Runtime.PYTHON_3_7,
-            code=_lambda.Code.asset('lambda'),
+            code=_lambda.Code.from_asset('lambda'),
             handler='hello.handler',
         )
 

--- a/code/python/main-workshop/cdk-workshop/hitcounter.py
+++ b/code/python/main-workshop/cdk-workshop/hitcounter.py
@@ -26,7 +26,7 @@ class HitCounter(core.Construct):
             self, 'HitCounterHandler',
             runtime=_lambda.Runtime.PYTHON_3_7,
             handler='hitcount.handler',
-            code=_lambda.Code.asset('lambda'),
+            code=_lambda.Code.from_asset('lambda'),
             environment={
                 'DOWNSTREAM_FUNCTION_NAME': downstream.function_name,
                 'HITS_TABLE_NAME': self._table.table_name

--- a/code/python/pipelines-workshop/cdk-workshop/cdk-workshop_stack.py
+++ b/code/python/pipelines-workshop/cdk-workshop/cdk-workshop_stack.py
@@ -23,7 +23,7 @@ class CdkWorkshopStack(core.Stack):
         my_lambda = _lambda.Function(
             self, 'HelloHandler',
             runtime=_lambda.Runtime.PYTHON_3_7,
-            code=_lambda.Code.asset('lambda'),
+            code=_lambda.Code.from_asset('lambda'),
             handler='hello.handler',
         )
 

--- a/code/python/pipelines-workshop/cdk-workshop/hitcounter.py
+++ b/code/python/pipelines-workshop/cdk-workshop/hitcounter.py
@@ -26,7 +26,7 @@ class HitCounter(core.Construct):
             self, 'HitCounterHandler',
             runtime=_lambda.Runtime.PYTHON_3_7,
             handler='hitcount.handler',
-            code=_lambda.Code.asset('lambda'),
+            code=_lambda.Code.from_asset('lambda'),
             environment={
                 'DOWNSTREAM_FUNCTION_NAME': downstream.function_name,
                 'HITS_TABLE_NAME': self._table.table_name

--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -75,7 +75,7 @@ environment variable values were references to other constructs.
 this.handler = new lambda.Function(this, 'HitCounterHandler', {
   runtime: lambda.Runtime.NODEJS_10_X,
   handler: 'hitcounter.handler',
-  code: lambda.Code.asset('lambda'),
+  code: lambda.Code.from_asset('lambda'),
   environment: {
     DOWNSTREAM_FUNCTION_NAME: props.downstream.functionName,
     HITS_TABLE_NAME: table.tableName

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.md
@@ -25,7 +25,7 @@ export class CdkWorkshopStack extends cdk.Stack {
 
     const hello = new lambda.Function(this, 'HelloHandler', {
       runtime: lambda.Runtime.NODEJS_10_X,
-      code: lambda.Code.asset(path.resolve(__dirname, '../lambda')),
+      code: lambda.Code.from_asset(path.resolve(__dirname, '../lambda')),
       handler: 'hello.handler',
     });
 

--- a/workshop/content/30-python/30-hello-cdk/300-apigw.md
+++ b/workshop/content/30-python/30-hello-cdk/300-apigw.md
@@ -40,7 +40,7 @@ class CdkworkshopStack(core.Stack):
         my_lambda = _lambda.Function(
             self, 'HelloHandler',
             runtime=_lambda.Runtime.PYTHON_3_7,
-            code=_lambda.Code.asset('lambda'),
+            code=_lambda.Code.from_asset('lambda'),
             handler='hello.handler',
         )
 

--- a/workshop/content/30-python/40-hit-counter/300-resources.md
+++ b/workshop/content/30-python/40-hit-counter/300-resources.md
@@ -33,7 +33,7 @@ class HitCounter(core.Construct):
             self, 'HitCountHandler',
             runtime=_lambda.Runtime.PYTHON_3_7,
             handler='hitcount.handler',
-            code=_lambda.Code.asset('lambda'),
+            code=_lambda.Code.from_asset('lambda'),
             environment={
                 'DOWNSTREAM_FUNCTION_NAME': downstream.function_name,
                 'HITS_TABLE_NAME': table.table_name,

--- a/workshop/content/30-python/40-hit-counter/600-permissions.md
+++ b/workshop/content/30-python/40-hit-counter/600-permissions.md
@@ -34,7 +34,7 @@ class HitCounter(core.Construct):
             self, 'HitCountHandler',
             runtime=_lambda.Runtime.PYTHON_3_7,
             handler='hitcount.handler',
-            code=_lambda.Code.asset('lambda'),
+            code=_lambda.Code.from_asset('lambda'),
             environment={
                 'DOWNSTREAM_FUNCTION_NAME': downstream.function_name,
                 'HITS_TABLE_NAME': table.table_name,
@@ -136,7 +136,7 @@ class HitCounter(core.Construct):
             self, 'HitCountHandler',
             runtime=_lambda.Runtime.PYTHON_3_7,
             handler='hitcount.handler',
-            code=_lambda.Code.asset('lambda'),
+            code=_lambda.Code.from_asset('lambda'),
             environment={
                 'DOWNSTREAM_FUNCTION_NAME': downstream.function_name,
                 'HITS_TABLE_NAME': table.table_name,

--- a/workshop/content/30-python/50-table-viewer/300-add.md
+++ b/workshop/content/30-python/50-table-viewer/300-add.md
@@ -29,7 +29,7 @@ class CdkworkshopStack(core.Stack):
         hello = _lambda.Function(
             self, 'HelloHandler',
             runtime=_lambda.Runtime.PYTHON_3_7,
-            code=_lambda.Code.asset('lambda'),
+            code=_lambda.Code.from_asset('lambda'),
             handler='hello.handler',
         )
 


### PR DESCRIPTION
`_lambda.Code.asset('path')` is deprecated method call on aws_cdk.aws_lambda 1.91.0 shown [here](https://docs.aws.amazon.com/cdk/api/latest/python/aws_cdk.aws_lambda/Code.html#aws_cdk.aws_lambda.Code.asset).

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes https://github.com/aws-samples/aws-cdk-intro-workshop/issues/197

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
