### PR TITLE
docs: Fix typos

### DIFF
--- a/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
@@ -5,7 +5,7 @@ import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 
 export class CdkWorkshopStack extends cdk.Stack {
-  constructor(scope: cdk.App, is: string, props?: cdk.StackProps) {
+  constructor(scope: cdk.App, i: string, props?: cdk.StackProps) {
     super(scope, is, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {

--- a/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
@@ -5,7 +5,7 @@ import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 
 export class CdkWorkshopStack extends cdk.Stack {
-  constructor(scope: cdk.App, i: string, props?: cdk.StackProps) {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, is, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {

--- a/code/typescript/pipelines-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/pipelines-workshop/lib/cdk-workshop-stack.ts
@@ -9,7 +9,7 @@ export class CdkWorkshopStack extends cdk.Stack {
   public readonly hcViewerUrl: cdk.CfnOutput;
   public readonly hcEndpoint: cdk.CfnOutput;
   
-  constructor(scope: cdk.Construct, is: string, props?: cdk.StackProps) {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, is, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {

--- a/code/typescript/tests-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/tests-workshop/lib/cdk-workshop-stack.ts
@@ -5,7 +5,7 @@ import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 
 class CdkWorkshopStack extends cdk.Stack {
-  constructor(scope: cdk.App, is: string, props?: cdk.StackProps) {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, is, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/3000-new-pipeline.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/3000-new-pipeline.md
@@ -73,7 +73,7 @@ git commit -am "MESSAGE" && git push
 npx cdk deploy
 ```
 
-CdkPipelines auto-update for each commit in a source repoh, so this is is the *last time* we will need to execute this command!
+CdkPipelines auto-update for each commit in a source repo, so this is is the *last time* we will need to execute this command!
 
 Once deployment is finished, you can go to the [CodePipeline console](https://console.aws.amazon.com/codesuite/codepipeline/pipelines) and you will see a new pipeline! If you navigate to it, it should look like this:
 

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/4000-build-stage.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/4000-build-stage.md
@@ -34,7 +34,7 @@ import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 
 export class CdkWorkshopStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, is: string, props?: cdk.StackProps) {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, is, props);
 
     // The rest of your code...
@@ -130,7 +130,7 @@ import { TableViewer } from 'cdk-dynamo-table-viewer';
 import * as path from 'path';
 
 export class CdkWorkshopStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, is: string, props?: cdk.StackProps) {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, is, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.md
@@ -20,7 +20,7 @@ export class CdkWorkshopStack extends cdk.Stack {
   public readonly hcViewerUrl: cdk.CfnOutput;
   public readonly hcEndpoint: cdk.CfnOutput;
   
-  constructor(scope: cdk.Construct, is: string, props?: cdk.StackProps) {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, is, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {

--- a/workshop/content/40-dotnet/70-advanced-topics/100-pipelines/3000-new-pipeline.md
+++ b/workshop/content/40-dotnet/70-advanced-topics/100-pipelines/3000-new-pipeline.md
@@ -89,7 +89,7 @@ git commit -am "MESSAGE" && git push
 npx cdk deploy
 ```
 
-CdkPipelines auto-update for each commit in a source repoh, so this is is the *last time* we will need to execute this command!
+CdkPipelines auto-update for each commit in a source repo, so this is is the *last time* we will need to execute this command!
 
 Once deployment is finished, you can go to the [CodePipeline console](https://console.aws.amazon.com/codesuite/codepipeline/pipelines) and you will see a new pipeline! If you navigate to it, it should look like this:
 


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixed a couple of typos; `repoh` -> `repo` and `is` -> `id`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
