### PR TITLE
docs: fix typo in _index.md for TypeScript pipelines

### DIFF
--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/_index.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/_index.md
@@ -8,7 +8,7 @@ chapter = true
 
 In this chapter we will create a Continuous Deployment (CD) pipeline for the app developed in previous chapters.
 
-CD is an important component to most web project, but can be challenging to set up with all the moving parts required. The [CDK Pipelines](https://docs.aws.amazon.com/cdk/latest/guide/cdk_pipeline.html) construct makes that proccess easy and streamlined from within your existing CDK infrastructure design.
+CD is an important component to most web project, but can be challenging to set up with all the moving parts required. The [CDK Pipelines](https://docs.aws.amazon.com/cdk/latest/guide/cdk_pipeline.html) construct makes that process easy and streamlined from within your existing CDK infrastructure design.
 
 These pipelines consist of "stages" that represent the phases of your deployment process from how the source code is managed, to how the fully built artifacts are deployed.
 


### PR DESCRIPTION
Fixes #203 
proccess -> process in `./workshop/content/20-typescript/70-advanced-topics/200-pipelines/_index.md`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
