### PR TITLE
fix: use of depreciated function "inline"

### DIFF
--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/2000-validation-tests.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/2000-validation-tests.md
@@ -71,7 +71,7 @@ test('read capacity can be configured', () => {
       downstream:  new lambda.Function(stack, 'TestFunction', {
         runtime: lambda.Runtime.NODEJS_10_X,
         handler: 'lambda.handler',
-        code: lambda.Code.inline('test')
+        code: lambda.Code.fromInline('test')
       }),
       readCapacity: 3
     });


### PR DESCRIPTION
Updated the code to use the newer "fromInline" instead of depreciated "inline".

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
