### PR TITLE
fix: function type Function to IFunction

### DIFF
--- a/workshop/content/20-typescript/40-hit-counter/600-permissions.md
+++ b/workshop/content/20-typescript/40-hit-counter/600-permissions.md
@@ -22,7 +22,7 @@ export interface HitCounterProps {
 export class HitCounter extends cdk.Construct {
 
   /** allows accessing the counter function */
-  public readonly handler: lambda.Function;
+  public readonly handler: lambda.IFunction;
 
   constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
     super(scope, id);

--- a/workshop/content/20-typescript/40-hit-counter/600-permissions.md
+++ b/workshop/content/20-typescript/40-hit-counter/600-permissions.md
@@ -121,7 +121,7 @@ import * as dynamodb from '@aws-cdk/aws-dynamodb';
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
-  downstream: lambda.Function;
+  downstream: lambda.IFunction;
 }
 
 export class HitCounter extends cdk.Construct {

--- a/workshop/content/20-typescript/40-hit-counter/600-permissions.md
+++ b/workshop/content/20-typescript/40-hit-counter/600-permissions.md
@@ -16,13 +16,13 @@ import * as dynamodb from '@aws-cdk/aws-dynamodb';
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
-  downstream: lambda.Function;
+  downstream: lambda.IFunction;
 }
 
 export class HitCounter extends cdk.Construct {
 
   /** allows accessing the counter function */
-  public readonly handler: lambda.IFunction;
+  public readonly handler: lambda.Function;
 
   constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
     super(scope, id);

--- a/workshop/content/20-typescript/50-table-viewer/400-expose-table.md
+++ b/workshop/content/20-typescript/50-table-viewer/400-expose-table.md
@@ -14,7 +14,7 @@ import * as dynamodb from '@aws-cdk/aws-dynamodb';
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
-  downstream: lambda.Function;
+  downstream: lambda.IFunction;
 }
 
 export class HitCounter extends cdk.Construct {


### PR DESCRIPTION
Thank you for the workshop. There seems to be a little type miss.

It should be changed hitcounter's downstream function type `Function` to `IFunction`.

In this page the hitcounter's downstream function type is `Function`.

https://cdkworkshop.com/20-typescript/40-hit-counter/600-permissions.html

Fixes  https://github.com/aws-samples/aws-cdk-intro-workshop/issues/120
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
