### PR TITLE
fix: Update NodeJS runtime version due to 10_X going EOL #231

### DIFF
--- a/code/csharp/main-workshop/src/CdkWorkshop/CdkWorkshopStack.cs
+++ b/code/csharp/main-workshop/src/CdkWorkshop/CdkWorkshopStack.cs
@@ -12,7 +12,7 @@ namespace CdkWorkshop
         {
             var hello = new Function(this, "HelloHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X,
+                Runtime = Runtime.NODEJS_14_X,
                 Code = Code.FromAsset("lambda"),
                 Handler = "hello.handler"
             });

--- a/code/csharp/main-workshop/src/CdkWorkshop/HitCounter.cs
+++ b/code/csharp/main-workshop/src/CdkWorkshop/HitCounter.cs
@@ -30,7 +30,7 @@ namespace CdkWorkshop
 
             Handler = new Function(this, "HitCounterHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X,
+                Runtime = Runtime.NODEJS_14_X,
                 Handler = "hitcounter.handler",
                 Code = Code.FromAsset("lambda"),
                 Environment = new Dictionary<string, string>

--- a/code/csharp/pipelines-workshop/src/CdkWorkshop/CdkWorkshopStack.cs
+++ b/code/csharp/pipelines-workshop/src/CdkWorkshop/CdkWorkshopStack.cs
@@ -15,7 +15,7 @@ namespace CdkWorkshop
         {
             var hello = new Function(this, "HelloHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X,
+                Runtime = Runtime.NODEJS_14_X,
                 Code = Code.FromAsset("lambda"),
                 Handler = "hello.handler"
             });

--- a/code/csharp/pipelines-workshop/src/CdkWorkshop/HitCounter.cs
+++ b/code/csharp/pipelines-workshop/src/CdkWorkshop/HitCounter.cs
@@ -30,7 +30,7 @@ namespace CdkWorkshop
 
             Handler = new Function(this, "HitCounterHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X,
+                Runtime = Runtime.NODEJS_14_X,
                 Handler = "hitcounter.handler",
                 Code = Code.FromAsset("lambda"),
                 Environment = new Dictionary<string, string>

--- a/code/java/main-workshop/src/main/java/com/myorg/CdkWorkshopStack.java
+++ b/code/java/main-workshop/src/main/java/com/myorg/CdkWorkshopStack.java
@@ -21,7 +21,7 @@ public class CdkWorkshopStack extends Stack {
 
         // Defines a new lambda resource
         final Function hello = Function.Builder.create(this, "HelloHandler")
-            .runtime(Runtime.NODEJS_10_X)    // execution environment
+            .runtime(Runtime.NODEJS_14_X)    // execution environment
             .code(Code.fromAsset("lambda"))  // code loaded from the "lambda" directory
             .handler("hello.handler")        // file is "hello", function is "handler"
             .build();

--- a/code/java/main-workshop/src/main/java/com/myorg/HitCounter.java
+++ b/code/java/main-workshop/src/main/java/com/myorg/HitCounter.java
@@ -31,7 +31,7 @@ public class HitCounter extends Construct {
         environment.put("HITS_TABLE_NAME", this.table.getTableName());
 
         this.handler = Function.Builder.create(this, "HitCounterHandler")
-            .runtime(Runtime.NODEJS_10_X)
+            .runtime(Runtime.NODEJS_14_X)
             .handler("hitcounter.handler")
             .code(Code.fromAsset("lambda"))
             .environment(environment)

--- a/code/java/pipelines-workshop/src/main/java/com/myorg/CdkWorkshopStack.java
+++ b/code/java/pipelines-workshop/src/main/java/com/myorg/CdkWorkshopStack.java
@@ -26,7 +26,7 @@ public class CdkWorkshopStack extends Stack {
 
         // Defines a new lambda resource
         final Function hello = Function.Builder.create(this, "HelloHandler")
-            .runtime(Runtime.NODEJS_10_X)    // execution environment
+            .runtime(Runtime.NODEJS_14_X)    // execution environment
             .code(Code.fromAsset("lambda"))  // code loaded from the "lambda" directory
             .handler("hello.handler")        // file is "hello", function is "handler"
             .build();

--- a/code/java/pipelines-workshop/src/main/java/com/myorg/HitCounter.java
+++ b/code/java/pipelines-workshop/src/main/java/com/myorg/HitCounter.java
@@ -31,7 +31,7 @@ public class HitCounter extends Construct {
         environment.put("HITS_TABLE_NAME", this.table.getTableName());
 
         this.handler = Function.Builder.create(this, "HitCounterHandler")
-            .runtime(Runtime.NODEJS_10_X)
+            .runtime(Runtime.NODEJS_14_X)
             .handler("hitcounter.handler")
             .code(Code.fromAsset("lambda"))
             .environment(environment)

--- a/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
@@ -9,7 +9,7 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.asset('lambda'),
       handler: 'hello.handler',
 

--- a/code/typescript/main-workshop/lib/hitcounter.ts
+++ b/code/typescript/main-workshop/lib/hitcounter.ts
@@ -23,7 +23,7 @@ export class HitCounter extends cdk.Construct {
     this.table = table;
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'hitcounter.handler',
       code: lambda.Code.asset('lambda'),
       environment: {

--- a/code/typescript/pipelines-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/pipelines-workshop/lib/cdk-workshop-stack.ts
@@ -13,7 +13,7 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.asset(path.resolve(__dirname, '../lambda')),
       handler: 'hello.handler',
 

--- a/code/typescript/pipelines-workshop/lib/hitcounter.ts
+++ b/code/typescript/pipelines-workshop/lib/hitcounter.ts
@@ -23,7 +23,7 @@ export class HitCounter extends cdk.Construct {
     this.table = table;
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'hitcounter.handler',
       code: lambda.Code.asset('lambda'),
       environment: {

--- a/code/typescript/pipelines-workshop/test/hitcounter.test.ts
+++ b/code/typescript/pipelines-workshop/test/hitcounter.test.ts
@@ -7,7 +7,7 @@ test('DynamoDB Table Created', () => {
     const stack = new cdk.Stack();
 
     const tableCreateLambda = new lambda.Function(stack, 'TestFunction', {
-        runtime: lambda.Runtime.NODEJS_10_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         handler: 'lambda.handler',
         code: lambda.Code.inline('test')
     });
@@ -29,7 +29,7 @@ test('Lambda Has Environment Variables', () => {
 
     new HitCounter(stack, 'MyTestConstruct', {
         downstream: new lambda.Function(stack, 'TestFunction', {
-            runtime: lambda.Runtime.NODEJS_10_X,
+            runtime: lambda.Runtime.NODEJS_14_X,
             handler: 'lambda.handler',
             code: lambda.Code.inline('test')
         })
@@ -55,7 +55,7 @@ test('Read Capacity can be configured', () => {
     expect(() => {
         new HitCounter(stack, 'MyTestConstruct', {
             downstream: new lambda.Function(stack, 'TestFunction', {
-                runtime: lambda.Runtime.NODEJS_10_X,
+                runtime: lambda.Runtime.NODEJS_14_X,
                 handler: 'lambda.handler',
                 code: lambda.Code.inline('test')
             }),

--- a/code/typescript/tests-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/tests-workshop/lib/cdk-workshop-stack.ts
@@ -9,7 +9,7 @@ class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.asset('lambda'),
       handler: 'hello.handler',
 

--- a/code/typescript/tests-workshop/lib/hitcounter.ts
+++ b/code/typescript/tests-workshop/lib/hitcounter.ts
@@ -23,7 +23,7 @@ export class HitCounter extends cdk.Construct {
     this.table = table;
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'hitcounter.handler',
       code: lambda.Code.asset('lambda'),
       environment: {

--- a/code/typescript/tests-workshop/test/hitcounter.test.ts
+++ b/code/typescript/tests-workshop/test/hitcounter.test.ts
@@ -7,7 +7,7 @@ test('DynamoDB Table Created', () => {
     const stack = new cdk.Stack();
 
     const tableCreateLambda = new lambda.Function(stack, 'TestFunction', {
-        runtime: lambda.Runtime.NODEJS_10_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         handler: 'lambda.handler',
         code: lambda.Code.inline('test')
     });
@@ -29,7 +29,7 @@ test('Lambda Has Environment Variables', () => {
 
     new HitCounter(stack, 'MyTestConstruct', {
         downstream: new lambda.Function(stack, 'TestFunction', {
-            runtime: lambda.Runtime.NODEJS_10_X,
+            runtime: lambda.Runtime.NODEJS_14_X,
             handler: 'lambda.handler',
             code: lambda.Code.inline('test')
         })
@@ -55,7 +55,7 @@ test('Read Capacity can be configured', () => {
     expect(() => {
         new HitCounter(stack, 'MyTestConstruct', {
             downstream: new lambda.Function(stack, 'TestFunction', {
-                runtime: lambda.Runtime.NODEJS_10_X,
+                runtime: lambda.Runtime.NODEJS_14_X,
                 handler: 'lambda.handler',
                 code: lambda.Code.inline('test')
             }),

--- a/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
+++ b/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
@@ -85,7 +85,7 @@ export class CdkWorkshopStack extends cdk.Stack {
 
     // defines an AWS Lambda resource
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,    // execution environment
+      runtime: lambda.Runtime.NODEJS_14_X,    // execution environment
       code: lambda.Code.fromAsset('lambda'),  // code loaded from "lambda" directory
       handler: 'hello.handler'                // file is "hello", function is "handler"
     });
@@ -95,7 +95,7 @@ export class CdkWorkshopStack extends cdk.Stack {
 
 A few things to notice:
 
-- Our function uses NodeJS 10.x runtime
+- Our function uses the NodeJS (`NODEJS_14_X`) runtime
 - The handler code is loaded from the `lambda` directory which we created
   earlier. Path is relative to where you execute `cdk` from, which is the
   project's root directory

--- a/workshop/content/20-typescript/30-hello-cdk/300-apigw.md
+++ b/workshop/content/20-typescript/30-hello-cdk/300-apigw.md
@@ -43,7 +43,7 @@ export class CdkWorkshopStack extends cdk.Stack {
 
     // defines an AWS Lambda resource
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,    // execution environment
+      runtime: lambda.Runtime.NODEJS_14_X,    // execution environment
       code: lambda.Code.fromAsset('lambda'),  // code loaded from "lambda" directory
       handler: 'hello.handler'                // file is "hello", function is "handler"
     });

--- a/workshop/content/20-typescript/40-hit-counter/300-resources.md
+++ b/workshop/content/20-typescript/40-hit-counter/300-resources.md
@@ -49,7 +49,7 @@ export class HitCounter extends cdk.Construct {
     });
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-        runtime: lambda.Runtime.NODEJS_10_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         handler: 'hitcounter.handler',
         code: lambda.Code.fromAsset('lambda'),
         environment: {

--- a/workshop/content/20-typescript/40-hit-counter/400-use.md
+++ b/workshop/content/20-typescript/40-hit-counter/400-use.md
@@ -19,7 +19,7 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.fromAsset('lambda'),
       handler: 'hello.handler'
     });

--- a/workshop/content/20-typescript/40-hit-counter/600-permissions.md
+++ b/workshop/content/20-typescript/40-hit-counter/600-permissions.md
@@ -32,7 +32,7 @@ export class HitCounter extends cdk.Construct {
     });
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'hitcounter.handler',
       code: lambda.Code.fromAsset('lambda'),
       environment: {
@@ -137,7 +137,7 @@ export class HitCounter extends cdk.Construct {
     });
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'hitcounter.handler',
       code: lambda.Code.fromAsset('lambda'),
       environment: {

--- a/workshop/content/20-typescript/50-table-viewer/300-add.md
+++ b/workshop/content/20-typescript/50-table-viewer/300-add.md
@@ -21,7 +21,7 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.fromAsset('lambda'),
       handler: 'hello.handler'
     });

--- a/workshop/content/20-typescript/50-table-viewer/400-expose-table.md
+++ b/workshop/content/20-typescript/50-table-viewer/400-expose-table.md
@@ -36,7 +36,7 @@ export class HitCounter extends cdk.Construct {
     this.table = table;
 
     this.handler = new lambda.Function(this, 'HitCounterHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'hitcounter.handler',
       code: lambda.Code.fromAsset('lambda'),
       environment: {
@@ -70,7 +70,7 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.fromAsset('lambda'),
       handler: 'hello.handler'
     });

--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -27,7 +27,7 @@ test('DynamoDB Table Created', () => {
   // WHEN
   new HitCounter(stack, 'MyTestConstruct', {
     downstream:  new lambda.Function(stack, 'TestFunction', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'lambda.handler',
       code: lambda.Code.fromInline('test')
     })
@@ -73,7 +73,7 @@ environment variable values were references to other constructs.
 
 {{<highlight ts "hl_lines=6-7">}}
 this.handler = new lambda.Function(this, 'HitCounterHandler', {
-  runtime: lambda.Runtime.NODEJS_10_X,
+  runtime: lambda.Runtime.NODEJS_14_X,
   handler: 'hitcounter.handler',
   code: lambda.Code.from_asset('lambda'),
   environment: {
@@ -95,7 +95,7 @@ test('Lambda Has Environment Variables', () => {
   // WHEN
   new HitCounter(stack, 'MyTestConstruct', {
     downstream:  new lambda.Function(stack, 'TestFunction', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'lambda.handler',
       code: lambda.Code.fromInline('test')
     })
@@ -181,7 +181,7 @@ test('Lambda Has Environment Variables', () => {
   // WHEN
   new HitCounter(stack, 'MyTestConstruct', {
     downstream:  new lambda.Function(stack, 'TestFunction', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'lambda.handler',
       code: lambda.Code.fromInline('test')
     })
@@ -239,7 +239,7 @@ test('DynamoDB Table Created With Encryption', () => {
   // WHEN
   new HitCounter(stack, 'MyTestConstruct', {
     downstream:  new lambda.Function(stack, 'TestFunction', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'lambda.handler',
       code: lambda.Code.fromInline('test')
     })

--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/2000-validation-tests.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/2000-validation-tests.md
@@ -69,7 +69,7 @@ test('read capacity can be configured', () => {
   expect(() => {
     new HitCounter(stack, 'MyTestConstruct', {
       downstream:  new lambda.Function(stack, 'TestFunction', {
-        runtime: lambda.Runtime.NODEJS_10_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         handler: 'lambda.handler',
         code: lambda.Code.inline('test')
       }),

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/4000-build-stage.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/4000-build-stage.md
@@ -134,7 +134,7 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.asset(path.resolve(__dirname, '../lambda')),
       handler: 'hello.handler',
 

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.md
@@ -24,7 +24,7 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.from_asset(path.resolve(__dirname, '../lambda')),
       handler: 'hello.handler',
     });

--- a/workshop/content/40-dotnet/30-hello-cdk/200-lambda.md
+++ b/workshop/content/40-dotnet/30-hello-cdk/200-lambda.md
@@ -79,7 +79,7 @@ namespace CdkWorkshop
             // Defines a new lambda resource
             var hello = new Function(this, "HelloHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X, // execution environment
+                Runtime = Runtime.NODEJS_14_X, // execution environment
                 Code = Code.FromAsset("lambda"), // Code loaded from the "lambda" directory
                 Handler = "hello.handler" // file is "hello", function is "handler"
             });
@@ -90,7 +90,7 @@ namespace CdkWorkshop
 
 A few things to notice:
 
-- Our function uses NodeJS 10.X runtime
+- Our function uses the NodeJS (`NODEJS_14_X`) runtime
 - The handler code is loaded from the `lambda` directory which we created
   earlier. Path is relative to where you execute `cdk` from, which is the
   project's root directory

--- a/workshop/content/40-dotnet/30-hello-cdk/300-apigw.md
+++ b/workshop/content/40-dotnet/30-hello-cdk/300-apigw.md
@@ -37,7 +37,7 @@ namespace CdkWorkshop
             // Defines a new lambda resource
             var hello = new Function(this, "HelloHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X, // execution environment
+                Runtime = Runtime.NODEJS_14_X, // execution environment
                 Code = Code.FromAsset("lambda"), // Code loaded from the "lambda" directory
                 Handler = "hello.handler" // file is "hello", function is "handler"
             });

--- a/workshop/content/40-dotnet/40-hit-counter/300-resources.md
+++ b/workshop/content/40-dotnet/40-hit-counter/300-resources.md
@@ -48,7 +48,7 @@ namespace CdkWorkshop
 
             Handler = new Function(this, "HitCounterHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X,
+                Runtime = Runtime.NODEJS_14_X,
                 Handler = "hitcounter.handler",
                 Code = Code.FromAsset("lambda"),
                 Environment = new Dictionary<string, string>

--- a/workshop/content/40-dotnet/40-hit-counter/400-use.md
+++ b/workshop/content/40-dotnet/40-hit-counter/400-use.md
@@ -22,7 +22,7 @@ namespace CdkWorkshop
             // Defines a new lambda resource
             var hello = new Function(this, "HelloHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X, // execution environment
+                Runtime = Runtime.NODEJS_14_X, // execution environment
                 Code = Code.FromAsset("lambda"), // Code loaded from the "lambda" directory
                 Handler = "hello.handler" // file is "hello", function is "handler"
             });

--- a/workshop/content/40-dotnet/40-hit-counter/600-permissions.md
+++ b/workshop/content/40-dotnet/40-hit-counter/600-permissions.md
@@ -40,7 +40,7 @@ namespace CdkWorkshop
 
             Handler = new Function(this, "HitCounterHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X,
+                Runtime = Runtime.NODEJS_14_X,
                 Handler = "hitcounter.handler",
                 Code = Code.FromAsset("lambda"),
                 Environment = new Dictionary<string, string>
@@ -155,7 +155,7 @@ namespace CdkWorkshop
 
             Handler = new Function(this, "HitCounterHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X,
+                Runtime = Runtime.NODEJS_14_X,
                 Handler = "hitcounter.handler",
                 Code = Code.FromAsset("lambda"),
                 Environment = new Dictionary<string, string>

--- a/workshop/content/40-dotnet/50-table-viewer/300-add.md
+++ b/workshop/content/40-dotnet/50-table-viewer/300-add.md
@@ -24,7 +24,7 @@ namespace CdkWorkshop
             // Defines a new lambda resource
             var hello = new Function(this, "HelloHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X, // execution environment
+                Runtime = Runtime.NODEJS_14_X, // execution environment
                 Code = Code.FromAsset("lambda"), // Code loaded from the "lambda" directory
                 Handler = "hello.handler" // file is "hello", function is "handler"
             });

--- a/workshop/content/40-dotnet/50-table-viewer/400-expose-table.md
+++ b/workshop/content/40-dotnet/50-table-viewer/400-expose-table.md
@@ -40,7 +40,7 @@ namespace CdkWorkshop
 
             Handler = new Function(this, "HitCounterHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X,
+                Runtime = Runtime.NODEJS_14_X,
                 Handler = "hitcounter.handler",
                 Code = Code.FromAsset("lambda"),
                 Environment = new Dictionary<string, string>
@@ -79,7 +79,7 @@ namespace CdkWorkshop
             // Defines a new lambda resource
             var hello = new Function(this, "HelloHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X, // execution environment
+                Runtime = Runtime.NODEJS_14_X, // execution environment
                 Code = Code.FromAsset("lambda"), // Code loaded from the "lambda" directory
                 Handler = "hello.handler" // file is "hello", function is "handler"
             });

--- a/workshop/content/40-dotnet/70-advanced-topics/100-pipelines/5000-test-actions.md
+++ b/workshop/content/40-dotnet/70-advanced-topics/100-pipelines/5000-test-actions.md
@@ -26,7 +26,7 @@ namespace CdkWorkshop
         {
             var hello = new Function(this, "HelloHandler", new FunctionProps
             {
-                Runtime = Runtime.NODEJS_10_X,
+                Runtime = Runtime.NODEJS_14_X,
                 Code = Code.FromAsset("lambda"),
                 Handler = "hello.handler"
             });

--- a/workshop/content/50-java/30-hello-cdk/200-lambda.md
+++ b/workshop/content/50-java/30-hello-cdk/200-lambda.md
@@ -102,7 +102,7 @@ public class CdkWorkshopStack extends Stack {
 
         // Defines a new lambda resource
         final Function hello = Function.Builder.create(this, "HelloHandler")
-            .runtime(Runtime.NODEJS_10_X)    // execution environment
+            .runtime(Runtime.NODEJS_14_X)    // execution environment
             .code(Code.fromAsset("lambda"))  // code loaded from the "lambda" directory
             .handler("hello.handler")        // file is "hello", function is "handler"
             .build();
@@ -113,7 +113,7 @@ public class CdkWorkshopStack extends Stack {
 
 A few things to notice:
 
-- Our function uses NodeJS 10.X runtime
+- Our function uses the NodeJS (`NODEJS_14_X`) runtime
 - The handler code is loaded from the `lambda` directory which we created
   earlier. Path is relative to where you execute `cdk` from, which is the
   project's root directory

--- a/workshop/content/50-java/30-hello-cdk/300-apigw.md
+++ b/workshop/content/50-java/30-hello-cdk/300-apigw.md
@@ -65,7 +65,7 @@ public class CdkWorkshopStack extends Stack {
 
         // Defines a new lambda resource
         final Function hello = Function.Builder.create(this, "HelloHandler")
-            .runtime(Runtime.NODEJS_10_X)    // execution environment
+            .runtime(Runtime.NODEJS_14_X)    // execution environment
             .code(Code.fromAsset("lambda"))  // code loaded from the "lambda" directory
             .handler("hello.handler")        // file is "hello", function is "handler"
             .build();

--- a/workshop/content/50-java/40-hit-counter/300-resources.md
+++ b/workshop/content/50-java/40-hit-counter/300-resources.md
@@ -77,7 +77,7 @@ public class HitCounter extends Construct {
         environment.put("HITS_TABLE_NAME", this.table.getTableName());
 
         this.handler = Function.Builder.create(this, "HitCounterHandler")
-            .runtime(Runtime.NODEJS_10_X)
+            .runtime(Runtime.NODEJS_14_X)
             .handler("hitcounter.handler")
             .code(Code.fromAsset("lambda"))
             .environment(environment)

--- a/workshop/content/50-java/40-hit-counter/400-use.md
+++ b/workshop/content/50-java/40-hit-counter/400-use.md
@@ -29,7 +29,7 @@ public class CdkWorkshopStack extends Stack {
 
         // Defines a new lambda resource
         final Function hello = Function.Builder.create(this, "HelloHandler")
-            .runtime(Runtime.NODEJS_10_X)    // execution environment
+            .runtime(Runtime.NODEJS_14_X)    // execution environment
             .code(Code.fromAsset("lambda"))  // code loaded from the "lambda" directory
             .handler("hello.handler")        // file is "hello", function is "handler"
             .build();

--- a/workshop/content/50-java/40-hit-counter/600-permissions.md
+++ b/workshop/content/50-java/40-hit-counter/600-permissions.md
@@ -43,7 +43,7 @@ public class HitCounter extends Construct {
         environment.put("HITS_TABLE_NAME", this.table.getTableName());
 
         this.handler = Function.Builder.create(this, "HitCounterHandler")
-            .runtime(Runtime.NODEJS_10_X)
+            .runtime(Runtime.NODEJS_14_X)
             .handler("hitcounter.handler")
             .code(Code.fromAsset("lambda"))
             .environment(environment)
@@ -172,7 +172,7 @@ public class HitCounter extends Construct {
         environment.put("HITS_TABLE_NAME", this.table.getTableName());
 
         this.handler = Function.Builder.create(this, "HitCounterHandler")
-            .runtime(Runtime.NODEJS_10_X)
+            .runtime(Runtime.NODEJS_14_X)
             .handler("hitcounter.handler")
             .code(Code.fromAsset("lambda"))
             .environment(environment)

--- a/workshop/content/50-java/50-table-viewer/300-add.md
+++ b/workshop/content/50-java/50-table-viewer/300-add.md
@@ -33,7 +33,7 @@ public class CdkWorkshopStack extends Stack {
 
         // Defines a new lambda resource
         final Function hello = Function.Builder.create(this, "HelloHandler")
-            .runtime(Runtime.NODEJS_10_X)    // execution environment
+            .runtime(Runtime.NODEJS_14_X)    // execution environment
             .code(Code.fromAsset("lambda"))  // code loaded from the "lambda" directory
             .handler("hello.handler")        // file is "hello", function is "handler"
             .build();

--- a/workshop/content/50-java/70-advanced-topics/100-pipelines/5000-test-actions.md
+++ b/workshop/content/50-java/70-advanced-topics/100-pipelines/5000-test-actions.md
@@ -37,7 +37,7 @@ public class CdkWorkshopStack extends Stack {
 
         // Defines a new lambda resource
         final Function hello = Function.Builder.create(this, "HelloHandler")
-            .runtime(Runtime.NODEJS_10_X)    // execution environment
+            .runtime(Runtime.NODEJS_14_X)    // execution environment
             .code(Code.fromAsset("lambda"))  // code loaded from the "lambda" directory
             .handler("hello.handler")        // file is "hello", function is "handler"
             .build();


### PR DESCRIPTION
Move NodeJS Lambda runtime to 14_X due to 10_X reaching EOL. 

Fixes #231 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
