### PR TITLE
fix(python) renamed `CdkworkshopStack` -> `CdkWorkshopStack` to resolve python error

### DIFF
--- a/workshop/content/30-python/30-hello-cdk/100-cleanup.md
+++ b/workshop/content/30-python/30-hello-cdk/100-cleanup.md
@@ -7,7 +7,7 @@ weight = 100
 
 The project created by `cdk init sample-app` includes an SQS queue and queue policy, an SNS
 topic and subscription. We're not going to use them in our
-project, so remove them from the `CdkworkshopStack` constructor.
+project, so remove them from the `CdkWorkshopStack` constructor.
 
 Open `cdkworkshop/cdkworkshop_stack.py` and clean it up. Eventually it should look like
 this:
@@ -18,7 +18,7 @@ from aws_cdk import (
 )
 
 
-class CdkworkshopStack(core.Stack):
+class CdkWorkshopStack(core.Stack):
 
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)

--- a/workshop/content/30-python/30-hello-cdk/200-lambda.md
+++ b/workshop/content/30-python/30-hello-cdk/200-lambda.md
@@ -74,7 +74,7 @@ from aws_cdk import (
 )
 
 
-class CdkworkshopStack(core.Stack):
+class CdkWorkshopStack(core.Stack):
 
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
@@ -101,7 +101,7 @@ A few things to notice:
 
 ## A word about constructs and constructors
 
-As you can see, the class constructors of both `CdkworkshopStack` and `lambda.Function`
+As you can see, the class constructors of both `CdkWorkshopStack` and `lambda.Function`
 (and many other classes in the CDK) have the signature `(scope, id,
 **kwargs)`. This is because all of these classes are __constructs__.
 Constructs are the basic building block of CDK apps. They represent abstract
@@ -165,8 +165,8 @@ Parameters
 [+] Parameter HelloHandler/Code/ArtifactHash HelloHandlerCodeArtifactHash5DF4E4B6: {"Type":"String","Description":"Artifact hash for asset \"hello-cdk-1/HelloHandler/Code\""}
 
 Resources
-[+] AWS::IAM::Role HelloHandler/ServiceRole HelloHandlerServiceRole11EF7C63 
-[+] AWS::Lambda::Function HelloHandler HelloHandler2E4FBA4D 
+[+] AWS::IAM::Role HelloHandler/ServiceRole HelloHandlerServiceRole11EF7C63
+[+] AWS::Lambda::Function HelloHandler HelloHandler2E4FBA4D
 ```
 
 As you can see, this code synthesizes an __AWS::Lambda::Function__ resource. It

--- a/workshop/content/30-python/30-hello-cdk/300-apigw.md
+++ b/workshop/content/30-python/30-hello-cdk/300-apigw.md
@@ -32,7 +32,7 @@ from aws_cdk import (
 )
 
 
-class CdkworkshopStack(core.Stack):
+class CdkWorkshopStack(core.Stack):
 
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
@@ -117,18 +117,18 @@ IAM Policy Changes
 (NOTE: There may be security-related changes not in this list. See http://bit.ly/cdk-2EhF7Np)
 
 Resources
-[+] AWS::Lambda::Permission HelloHandler/ApiPermission.ANY.. HelloHandlerApiPermissionANYAC4E141E 
-[+] AWS::Lambda::Permission HelloHandler/ApiPermission.Test.ANY.. HelloHandlerApiPermissionTestANYDDD56D72 
-[+] AWS::Lambda::Permission HelloHandler/ApiPermission.ANY..{proxy+} HelloHandlerApiPermissionANYproxy90E90CD6 
-[+] AWS::Lambda::Permission HelloHandler/ApiPermission.Test.ANY..{proxy+} HelloHandlerApiPermissionTestANYproxy9803526C 
-[+] AWS::ApiGateway::RestApi Endpoint EndpointEEF1FD8F 
-[+] AWS::ApiGateway::Deployment Endpoint/Deployment EndpointDeployment318525DAb462c597ccb914d9fc1c10f664ed81ca 
-[+] AWS::ApiGateway::Stage Endpoint/DeploymentStage.prod EndpointDeploymentStageprodB78BEEA0 
-[+] AWS::IAM::Role Endpoint/CloudWatchRole EndpointCloudWatchRoleC3C64E0F 
-[+] AWS::ApiGateway::Account Endpoint/Account EndpointAccountB8304247 
-[+] AWS::ApiGateway::Resource Endpoint/Default/{proxy+} Endpointproxy39E2174E 
-[+] AWS::ApiGateway::Method Endpoint/Default/{proxy+}/ANY EndpointproxyANYC09721C5 
-[+] AWS::ApiGateway::Method Endpoint/Default/ANY EndpointANY485C938B 
+[+] AWS::Lambda::Permission HelloHandler/ApiPermission.ANY.. HelloHandlerApiPermissionANYAC4E141E
+[+] AWS::Lambda::Permission HelloHandler/ApiPermission.Test.ANY.. HelloHandlerApiPermissionTestANYDDD56D72
+[+] AWS::Lambda::Permission HelloHandler/ApiPermission.ANY..{proxy+} HelloHandlerApiPermissionANYproxy90E90CD6
+[+] AWS::Lambda::Permission HelloHandler/ApiPermission.Test.ANY..{proxy+} HelloHandlerApiPermissionTestANYproxy9803526C
+[+] AWS::ApiGateway::RestApi Endpoint EndpointEEF1FD8F
+[+] AWS::ApiGateway::Deployment Endpoint/Deployment EndpointDeployment318525DAb462c597ccb914d9fc1c10f664ed81ca
+[+] AWS::ApiGateway::Stage Endpoint/DeploymentStage.prod EndpointDeploymentStageprodB78BEEA0
+[+] AWS::IAM::Role Endpoint/CloudWatchRole EndpointCloudWatchRoleC3C64E0F
+[+] AWS::ApiGateway::Account Endpoint/Account EndpointAccountB8304247
+[+] AWS::ApiGateway::Resource Endpoint/Default/{proxy+} Endpointproxy39E2174E
+[+] AWS::ApiGateway::Method Endpoint/Default/{proxy+}/ANY EndpointproxyANYC09721C5
+[+] AWS::ApiGateway::Method Endpoint/Default/ANY EndpointANY485C938B
 
 Outputs
 [+] Output Endpoint/Endpoint Endpoint8024A810: {"Value":{"Fn::Join":["",["https://",{"Ref":"EndpointEEF1FD8F"},".execute-api.us-east-2.",{"Ref":"AWS::URLSuffix"},"/",{"Ref":"EndpointDeploymentStageprodB78BEEA0"},"/"]]}}

--- a/workshop/content/30-python/40-hit-counter/400-use.md
+++ b/workshop/content/30-python/40-hit-counter/400-use.md
@@ -18,7 +18,7 @@ from aws_cdk import (
 from .hitcounter import HitCounter
 
 
-class CdkworkshopStack(core.Stack):
+class CdkWorkshopStack(core.Stack):
 
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)

--- a/workshop/content/30-python/50-table-viewer/300-add.md
+++ b/workshop/content/30-python/50-table-viewer/300-add.md
@@ -20,7 +20,7 @@ from cdk_dynamo_table_viewer import TableViewer
 from hitcounter import HitCounter
 
 
-class CdkworkshopStack(core.Stack):
+class CdkWorkshopStack(core.Stack):
 
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
@@ -47,7 +47,7 @@ class CdkworkshopStack(core.Stack):
             self, 'ViewHitCounter',
             title='Hello Hits',
             table=??????
-        )  
+        )
 {{</highlight>}}
 
 ## What about the table?

--- a/workshop/content/30-python/50-table-viewer/400-expose-table.md
+++ b/workshop/content/30-python/50-table-viewer/400-expose-table.md
@@ -62,7 +62,7 @@ from cdk_dynamo_table_viewer import TableViewer
 from hitcounter import HitCounter
 
 
-class CdkworkshopStack(core.Stack):
+class CdkWorkshopStack(core.Stack):
 
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
@@ -89,5 +89,5 @@ class CdkworkshopStack(core.Stack):
             self, 'ViewHitCounter',
             title='Hello Hits',
             table=hello_with_counter.table,
-        )  
+        )
 {{</highlight>}}


### PR DESCRIPTION
## Summary

This PR renames the python classname `CdkworkshopStack` to `CdkWorkshopStack`. This was causing python to throw a casing error when users copied code from the snippet.

Fixes #244

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
