### PR TITLE
feat: add event notification for pipeline failure

### DIFF
--- a/cdkworkshop.com/pipeline.ts
+++ b/cdkworkshop.com/pipeline.ts
@@ -2,6 +2,10 @@ import { Construct, Stack, StackProps, SecretValue } from '@aws-cdk/core';
 import * as pipelines from '@aws-cdk/pipelines';
 import * as cpipe from '@aws-cdk/aws-codepipeline';
 import * as cpipe_actions from '@aws-cdk/aws-codepipeline-actions';
+import * as sns from '@aws-cdk/aws-sns';
+import * as subs from '@aws-cdk/aws-sns-subscriptions';
+import * as events from '@aws-cdk/aws-events';
+import * as targets from '@aws-cdk/aws-events-targets';
 import { TheCdkWorkshopStage } from './cdkworkshop.com';
 
 export class PipelineStack extends Stack {
@@ -36,5 +40,27 @@ export class PipelineStack extends Stack {
     });
 
     pipeline.addApplicationStage(new TheCdkWorkshopStage(this, 'Prod'));
+
+    const failTopic = new sns.Topic(this, 'PipelineFailTopic');
+
+    failTopic.addSubscription(new subs.EmailSubscription(
+      'aws-sdk-opensource-support-cdk-primary@amazon.com'
+    ));
+
+    const failEvent = new events.Rule(this, 'PipelineFailedEvent', {
+      eventPattern: {
+        source: [ 'aws.codepipeline' ],
+        detailType: [ 'CodePipeline Pipeline Execution State Change' ],
+        detail: {
+          'state': [ 'FAILED' ],
+          'pipeline': [ 'WorkshopPipeline' ]
+        },
+      }
+    });
+
+    failEvent.addTarget(new targets.SnsTopic(failTopic, {
+      message: events.RuleTargetInput.fromText(
+        `The Pipeline '${events.EventField.fromPath('$.detail.pipeline')}' has ${events.EventField.fromPath('$.detail.state')}`)
+    }));
   }
 }


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Adds a Cloudwatch alarm notification to email on pipeline failures.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
