### PR TITLE
fix: pipeline build fails due to invalid file path

### DIFF
--- a/cdkworkshop.com/pipeline.ts
+++ b/cdkworkshop.com/pipeline.ts
@@ -26,6 +26,7 @@ export class PipelineStack extends Stack {
           'npm run build',
           'npx cdk synth'
         ],
+        primaryOutputDirectory: 'cdkworkshop.com/cdk.out',
       }),
     });
 


### PR DESCRIPTION
The pipeline build is failing after the conversion to CDKv2 and the new
pipelines API in the post-build phase:

```
[Container] 2021/11/01 11:43:11 Phase context status code:  Message:
[Container] 2021/11/01 11:43:11 Expanding base directory path: cdk.out
[Container] 2021/11/01 11:43:11 Assembling file list
[Container] 2021/11/01 11:43:11 Expanding cdk.out
[Container] 2021/11/01 11:43:11 Skipping invalid file path cdk.out
```

This is because the working directory for the post-build phase is the package
root, instead of the CDK root (./cdkworkshop.com).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
