### PR TITLE
feat(test-workshop): typescript tests now use assertions module

### DIFF
--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/_index.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/_index.md
@@ -6,37 +6,34 @@ weight = 100
 ## Testing Constructs (Optional)
 
 The [CDK Developer Guide](https://docs.aws.amazon.com/cdk/latest/guide/testing.html) has a good guide on
-testing constructs. For this section of the workshop we are going to use the [Fine-Grained Assertions](https://docs.aws.amazon.com/cdk/latest/guide/testing.html#testing_fine_grained) and [Validation](https://docs.aws.amazon.com/cdk/latest/guide/testing.html#testing_validation) type tests.
+testing constructs. For this section of the workshop we are going to use the [Fine-Grained Assertions](https://docs.aws.amazon.com/cdk/latest/guide/testing.html#testing_fine_grained)
+and [Validation](https://docs.aws.amazon.com/cdk/latest/guide/testing.html#testing_validation) type tests.
 
 ### Prerequisites
 
 1. Install the required testing packages.
 
 ```bash
-$ npm install --save-dev jest @types/jest @aws-cdk/assert
+$ npm install --save-dev jest @types/jest @aws-cdk/assertions
 ```
 
 #### CDK assert Library
 
-We will be using the CDK `assert` (`@aws-cdk/assert`) library throughout this section.
+We will be using the CDK `assertions` (`@aws-cdk/assertions`) library throughout this section.
 The library contains several helper functions for writing unit and integration tests.
 
 
-For this workshop we will mostly be using the `haveResource` function. This helper is used when you
+For this workshop we will mostly be using the `hasResourceProperties` function. This helper is used when you
 only care that a resource of a particular type exists (regardless of its logical identfier), and that _some_
 properties are set to specific values.
 
 Example:
 
 ```ts
-expect(stack).to(haveResource('AWS::CertificateManager::Certificate', {
+template.hasResourceProperties('AWS::CertificateManager::Certificate', {
     DomainName: 'test.example.com',
     // Note: some properties omitted here
-
-    ShouldNotExist: ABSENT
-}));
+});
 ```
 
-`ABSENT` is a magic value to assert that a particular key in an object is *not* set (or set to `undefined`).
-
-To see the rest of the documentation, please read the docs [here](https://github.com/aws/aws-cdk/blob/master/packages/%40aws-cdk/assert-internal/README.md).
+To see the rest of the documentation, please read the docs [here](https://github.com/aws/aws-cdk/blob/master/packages/%40aws-cdk/assertions/README.md).

--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/_index.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/_index.md
@@ -32,8 +32,12 @@ Example:
 ```ts
 template.hasResourceProperties('AWS::CertificateManager::Certificate', {
     DomainName: 'test.example.com',
+
+    ShouldNotExist: Match.absent(),
     // Note: some properties omitted here
 });
 ```
 
-To see the rest of the documentation, please read the docs [here](https://github.com/aws/aws-cdk/blob/master/packages/%40aws-cdk/assertions/README.md).
+`Match.absent()` can be used to assert that a particular key in an object is *not* set (or set to `undefined`).
+
+To see the rest of the documentation, please read the docs [here](https://docs.aws.amazon.com/cdk/api/latest/docs/assertions-readme.html).


### PR DESCRIPTION
Updated the TypeScript Testing Constructs section of the workshop to use
the new @aws-cdk/assertions module


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
