### PR TITLE
fix: invalid reference to the stack

### DIFF
--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/4000-build-stage.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/4000-build-stage.md
@@ -12,14 +12,14 @@ Create a new file in `cdk_workshop` called `pipeline_stage.py` with the code bel
 from aws_cdk import (
     core
 )
-from pypipworkshop_stack import PypipworkshopStack
+from cdk_workshop_stack import CdkWorkshopStack
 
 class WorkshopPipelineStage(core.Stage):
 
     def __init__(self, scope: core.Construct, id: str, **kwargs):
         super().__init__(scope, id, **kwargs)
 
-        service = PypipworkshopStack(self, 'WebService')
+        service = CdkWorkshopStack(self, 'WebService')
 
 {{</highlight>}}
 

--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/4000-build-stage.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/4000-build-stage.md
@@ -12,7 +12,7 @@ Create a new file in `cdk_workshop` called `pipeline_stage.py` with the code bel
 from aws_cdk import (
     core
 )
-from cdk_workshop_stack import CdkWorkshopStack
+from .cdk_workshop_stack import CdkWorkshopStack
 
 class WorkshopPipelineStage(core.Stage):
 

--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/5000-test-actions.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/5000-test-actions.md
@@ -136,7 +136,7 @@ With a slight modification to `cdk_workshop/pipeline_stage.py` we can expose the
 from aws_cdk import (
     core
 )
-from cdk_workshop_stack import CdkWorkshopStack
+from .cdk_workshop_stack import CdkWorkshopStack
 
 class WorkshopPipelineStage(core.Stage):
 

--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/5000-test-actions.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/5000-test-actions.md
@@ -136,7 +136,7 @@ With a slight modification to `cdk_workshop/pipeline_stage.py` we can expose the
 from aws_cdk import (
     core
 )
-from pypipworkshop_stack import PypipworkshopStack
+from cdk_workshop_stack import CdkWorkshopStack
 
 class WorkshopPipelineStage(core.Stage):
 
@@ -151,7 +151,7 @@ class WorkshopPipelineStage(core.Stage):
     def __init__(self, scope: core.Construct, id: str, **kwargs):
         super().__init__(scope, id, **kwargs)
 
-        service = PypipworkshopStack(self, 'WebService')
+        service = CdkWorkshopStack(self, 'WebService')
 
         self._hc_enpdoint = service.hc_endpoint
         self._hc_viewer_url = service.hc_viewer_url


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # [309](https://github.com/aws-samples/aws-cdk-intro-workshop/issues/309)

The sample code [here](https://github.com/aws-samples/aws-cdk-intro-workshop/tree/master/code/python/pipelines-workshop) already referring to the right stack, however the workshop instruction is not up to date.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
