### PR TITLE
docs(python/advanced-topics/construct-testing) added `aws-cdk.assertions` to pip install command

### DIFF
--- a/workshop/content/30-python/70-advanced-topics/100-construct-testing/_index.md
+++ b/workshop/content/30-python/70-advanced-topics/100-construct-testing/_index.md
@@ -13,7 +13,7 @@ testing constructs. For this section of the workshop we are going to use the [Fi
 1. Install the required testing packages.
 
 ```bash
-$ pip install pytest
+$ pip install pytest aws-cdk.assertions
 ```
 
 #### CDK assert Library


### PR DESCRIPTION
## Summary

This PR adds `aws-cdk.assertions` to the list of pip dependencies to install before writing CDK tests.

Fixes: https://github.com/aws/aws-cdk/issues/17310

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
