### PR TITLE
feat: update typescript workshop to v2

### DIFF
--- a/code/typescript/main-workshop/bin/cdk-workshop.ts
+++ b/code/typescript/main-workshop/bin/cdk-workshop.ts
@@ -1,4 +1,4 @@
-import { App } from '@aws-cdk/core';
+import { App } from 'aws-cdk-lib';
 import { CdkWorkshopStack } from '../lib/cdk-workshop-stack';
 
 const app = new App();

--- a/code/typescript/main-workshop/cdk.json
+++ b/code/typescript/main-workshop/cdk.json
@@ -2,16 +2,8 @@
   "app": "npx ts-node --prefer-ts-exts bin/cdk-workshop.ts",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
-    "aws-cdk:enableDiffNoFail": true,
     "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
     "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
   }

--- a/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
@@ -1,6 +1,6 @@
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as apigw from '@aws-cdk/aws-apigateway';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 

--- a/code/typescript/main-workshop/lib/hitcounter.ts
+++ b/code/typescript/main-workshop/lib/hitcounter.ts
@@ -1,20 +1,20 @@
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as dynamodb from '@aws-cdk/aws-dynamodb';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
   downstream: lambda.IFunction;
 }
 
-export class HitCounter extends cdk.Construct {
+export class HitCounter extends Construct {
   /** allows accessing the counter function */
   public readonly handler: lambda.Function;
 
   /** the hit counter table */
   public readonly table: dynamodb.Table;
 
-  constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
+  constructor(scope: Construct, id: string, props: HitCounterProps) {
     super(scope, id);
 
     const table = new dynamodb.Table(this, 'Hits', {

--- a/code/typescript/main-workshop/package-lock.json
+++ b/code/typescript/main-workshop/package-lock.json
@@ -5,211 +5,201 @@
   "requires": true,
   "dependencies": {
     "@aws-cdk/assets": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.131.0.tgz",
-      "integrity": "sha512-gl3NUiTpcdhnE0omzICRJzFxjOyQdu7PY30SQk65zqaZeI1bY4DTfx5i/VIgCa3v9zAb/ypPic0J0XJ+HINClg==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.118.0.tgz",
+      "integrity": "sha512-v8j4rTCt1tFIhbs11drJ3SSzo57VftO6/PjRCcYg3i1RmrroIiBGZxtb3VRUXS+un5GqVMEbevu3PamIghxINw==",
       "requires": {
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-acmpca": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-acmpca/-/aws-acmpca-1.131.0.tgz",
-      "integrity": "sha512-UEM/7SEXfIIpLYJWdfNe9fmgHa8YcFyfTUk0c7QSAYjfuLGkZB5U89RftadgWyDNQQxOg6Qzg++auXBoL8K21w==",
-      "requires": {
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-apigateway": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.131.0.tgz",
-      "integrity": "sha512-0kt7ZLibQO4UG4jNpVvL4BJFkWIw2+A4H7H+d9PF/Evi//aTXQ6vR3P+tMZAg9S+3ll85KlfZFgqY6MHdliKJA==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.118.0.tgz",
+      "integrity": "sha512-x6EPTg6qP9vhdiIOgFpOwHzGyXRK9lzO/RtnYgFLiirOnsnezMjD05mXCNjSpP+v8PNjPTp473UZ8c9enRwxPg==",
       "requires": {
-        "@aws-cdk/aws-certificatemanager": "1.131.0",
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-cognito": "1.131.0",
-        "@aws-cdk/aws-ec2": "1.131.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-lambda": "1.131.0",
-        "@aws-cdk/aws-logs": "1.131.0",
-        "@aws-cdk/aws-s3": "1.131.0",
-        "@aws-cdk/aws-s3-assets": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
+        "@aws-cdk/aws-certificatemanager": "1.118.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-cognito": "1.118.0",
+        "@aws-cdk/aws-ec2": "1.118.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-lambda": "1.118.0",
+        "@aws-cdk/aws-logs": "1.118.0",
+        "@aws-cdk/aws-s3": "1.118.0",
+        "@aws-cdk/aws-s3-assets": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-applicationautoscaling": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.131.0.tgz",
-      "integrity": "sha512-08wSYLE8jAe455TBcqaEVTBhFqmbdywjq40894g/qCkarA5lQxi7FdhCv+mycOAN6ipdNl2AAWHgGcwWpK//uw==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.118.0.tgz",
+      "integrity": "sha512-ltaQHzLzhozT8IE0VLfzVdui1zWJpr5aBNZWKTiXldiHL174YrOMm6GZYvuFl3SdS7YYD4iUQEl9P9ElkxSJwA==",
       "requires": {
-        "@aws-cdk/aws-autoscaling-common": "1.131.0",
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-autoscaling-common": "1.118.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-autoscaling-common": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.131.0.tgz",
-      "integrity": "sha512-eoLYT9e+Oy/WleXdu0YZkTfwFpYdYUX4KW8EWflqAs2DCboT+YMNIJSYYQPgH1PZ0Zp1zALVmmEjpcyJWlOjWg==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.118.0.tgz",
+      "integrity": "sha512-2mtoj4g7B3/6nYecjRk/qgvkdfhkDy4VMb7OLa6cJCwCEMwbGvJx3y6bLOcmWhX6JGwXmuKSVycxksXpdsS7Zg==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-certificatemanager": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.131.0.tgz",
-      "integrity": "sha512-3t1Afy5Az+MY4WRZrDMATC3HXbq8g4eJlD+NTZOUjwmHFvK3TQLnmXjWBU6hh7k9myv1Iu7XJjRLxMWOHYgNEw==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.118.0.tgz",
+      "integrity": "sha512-WjJnOWG6LgPgpdWeet9vmIOB+ycLFs+vxb77nkC63xlq9hbWZml/UE6/QBU4sV2p3JMV6P3kn6LWk1OLVYo4Qg==",
       "requires": {
-        "@aws-cdk/aws-acmpca": "1.131.0",
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-lambda": "1.131.0",
-        "@aws-cdk/aws-route53": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-lambda": "1.118.0",
+        "@aws-cdk/aws-route53": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-cloudformation": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.131.0.tgz",
-      "integrity": "sha512-vFTW3XIoiT4NLSXEKXz0cY62fM5leNnjZtiQUN07GWTaSqyWXjZCy4/GtEjwa9gYlsY8jicNtir9GbzlPcRf1Q==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.118.0.tgz",
+      "integrity": "sha512-O2mACRUbGY3+pgbzbSa0OwTFdqTk/SqOwu9tZhKL0l8lSTkELc2YTMUCYsbkQFJD34sY1khbT6uJ5rA9udjQGA==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-lambda": "1.131.0",
-        "@aws-cdk/aws-s3": "1.131.0",
-        "@aws-cdk/aws-sns": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-lambda": "1.118.0",
+        "@aws-cdk/aws-s3": "1.118.0",
+        "@aws-cdk/aws-sns": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-cloudwatch": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.131.0.tgz",
-      "integrity": "sha512-eT6Y61bzCr47MW+RxHNjSVwhxtsomTaG2cFeuKzPV742wfEUGH4DoNK3iwrLoeBZA//1YDKjFCDJ6BryTXTsGw==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.118.0.tgz",
+      "integrity": "sha512-VyrhQTVN0oEpjqs6SNvf/UzvQGWlDwJVyH8NGf6sFhtWMtgryHdTvM4UKp5o+a4DRicZjoAfZgG8VOqytcEMVg==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-codeguruprofiler": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.131.0.tgz",
-      "integrity": "sha512-ulfNQIOn14l7zdFVLCMKvI2i/TDIOpzRtWApwVZRx1+QejUy6XFB53YsbG8r6oG/C10gIv/qRWZVXU0czm24Kw==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.118.0.tgz",
+      "integrity": "sha512-bcq7f2n4ffIhYEjF02OhVqqmrdxTfZs/PsN68lMvd7my/cek9u0OcvY0l67VHwc9tnOYblUHCkaKGzyKfQou5A==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-codestarnotifications": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.131.0.tgz",
-      "integrity": "sha512-aN6bmjabpOE2HRFTBqvraopzltuujxUlUVOJM/ijeohzYN6h//p/OcF2ywJ9vZQ/Wdz/mUnsH34hXQQ766PE0g==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.118.0.tgz",
+      "integrity": "sha512-zKgVbpcAemCHNAGfuZh+HP18cPOfREowFlZMHQ+/RO7Rk2mG23N7iqdH2X+B/SQxUZ1gQ7AsDNvO8qeWmE4kXw==",
       "requires": {
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-cognito": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.131.0.tgz",
-      "integrity": "sha512-fUrgOOvZY+4JgWz9vLry9JQiHqhKH3l/Ay0l2xRnPygCa5xgMDh0VHJ2FYVysl6lIhj26uea9Sk5nTqokeTyRQ==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.118.0.tgz",
+      "integrity": "sha512-qL7a8eudOXQ0+IqP33FFlXCvlUr1JTMCS581ZY+9/6bv4jyp8zwdsM+aWaENQg9jLdAEonD+KW8fXQbU9BTIVg==",
       "requires": {
-        "@aws-cdk/aws-certificatemanager": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-lambda": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/custom-resources": "1.131.0",
+        "@aws-cdk/aws-certificatemanager": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-lambda": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/custom-resources": "1.118.0",
         "constructs": "^3.3.69",
         "punycode": "^2.1.1"
       },
       "dependencies": {
         "punycode": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false
         }
       }
     },
     "@aws-cdk/aws-dynamodb": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.131.0.tgz",
-      "integrity": "sha512-smS4su5wu8XP1C41TMzAPkQYoj39h7VGIaADbjWlEzwrWczaY8qWBv+eJctJ/6xuepUms3E7kj+/gj9scQbmkg==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.118.0.tgz",
+      "integrity": "sha512-fQXcTdwoeL7cxo2YM8lf31+4LjcGuTXUBQdEJ4QoBAa+vv2MIUacVXOVIfXMJM4DUy6YTa5itPvtoJ0IpQDGQQ==",
       "requires": {
-        "@aws-cdk/aws-applicationautoscaling": "1.131.0",
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kinesis": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/aws-lambda": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/custom-resources": "1.131.0",
+        "@aws-cdk/aws-applicationautoscaling": "1.118.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kinesis": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/aws-lambda": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/custom-resources": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-ec2": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.131.0.tgz",
-      "integrity": "sha512-les6UcYAJsqTJgZeMrmdIIJ8J+Obsa8h3uwW/w20UAhI640qRlLkQmAiZu04v/VNXGQ13VWdOWe3STN/C/hfLA==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.118.0.tgz",
+      "integrity": "sha512-0QMvYZFZFPmOi2OipMzpuYbKZtli7H15p+kZtHu2p/q9c5+GVPLRoHd0DjEf52sX8pAlkWgzht+4J5myh/Xhmw==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/aws-logs": "1.131.0",
-        "@aws-cdk/aws-s3": "1.131.0",
-        "@aws-cdk/aws-s3-assets": "1.131.0",
-        "@aws-cdk/aws-ssm": "1.131.0",
-        "@aws-cdk/cloud-assembly-schema": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
-        "@aws-cdk/region-info": "1.131.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/aws-logs": "1.118.0",
+        "@aws-cdk/aws-s3": "1.118.0",
+        "@aws-cdk/aws-s3-assets": "1.118.0",
+        "@aws-cdk/aws-ssm": "1.118.0",
+        "@aws-cdk/cloud-assembly-schema": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
+        "@aws-cdk/region-info": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-ecr": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.131.0.tgz",
-      "integrity": "sha512-RXASOgovwKZU0UKP2EcS9NuDXg/GGTg1vPZH0M5ldsYE6EBx7K8HKon84FMa1OvITKDp+Z/IigVG7NfgnSVP5w==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.118.0.tgz",
+      "integrity": "sha512-pxQ3vYG+mgB7v8luAxaWmZcy9marWvhWctzbPIwVUKlBly4I3ZL4PGUrx9sdjvDa/FQrBCMdoY8V6ZjDjDN5Dw==",
       "requires": {
-        "@aws-cdk/aws-events": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-events": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-ecr-assets": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.131.0.tgz",
-      "integrity": "sha512-D99OxxWre6v9T12XKDIpSQ2jaT8kKnTmeiEt0BE4p1NYMBnu3TZXzMO1gl5+2MM+Aiys/I+XqWNeMhCfrFgt1g==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.118.0.tgz",
+      "integrity": "sha512-2d4CGrduSnSdHJ1QzNYwt82jMBOr7ZbqbedMEsNHWoJAFG26Wi3t4k7Jx+mWUoy4VnvQwq4BlKYI1UrVdQf5/w==",
       "requires": {
-        "@aws-cdk/assets": "1.131.0",
-        "@aws-cdk/aws-ecr": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-s3": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
+        "@aws-cdk/assets": "1.118.0",
+        "@aws-cdk/aws-ecr": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-s3": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
         "constructs": "^3.3.69",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -217,11 +207,11 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -229,214 +219,213 @@
       }
     },
     "@aws-cdk/aws-efs": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.131.0.tgz",
-      "integrity": "sha512-tjeWzlB0T2BXdqQjapW3H5zTG0d5V0h2kRe2OfaWXnAWwsaK3mdJJfG3BPZpCMkdnuyQh5y/HWujA8xww+uYCQ==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.118.0.tgz",
+      "integrity": "sha512-ej+Z8LkwS8bAkv4GhhnbJ4s9WD7bt8OjQx300cbV4cPM+IOJviFkt4RJXp6/jbLF6iq1KxT6m+8CNQVoRqsu4Q==",
       "requires": {
-        "@aws-cdk/aws-ec2": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/cloud-assembly-schema": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
+        "@aws-cdk/aws-ec2": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/cloud-assembly-schema": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-elasticloadbalancingv2": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.131.0.tgz",
-      "integrity": "sha512-ZM8J+a0QeUVpL3drO7bOTfUp/ntKb5S8q9CYyU2f5952TqLIb1/3uUq/PcT0pAmS7lcNb17lvkgS0vs1Vp5eDA==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.118.0.tgz",
+      "integrity": "sha512-TmXeY4aZIAzVjBzKKnyuuqf/JwdavJWOIDKxhd2JTXqKkSspO5h6eE0IJPWmTg5AKtiGUdpHu9hhjgFCYQYxRg==",
       "requires": {
-        "@aws-cdk/aws-certificatemanager": "1.131.0",
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-ec2": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-lambda": "1.131.0",
-        "@aws-cdk/aws-s3": "1.131.0",
-        "@aws-cdk/cloud-assembly-schema": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
-        "@aws-cdk/region-info": "1.131.0",
+        "@aws-cdk/aws-certificatemanager": "1.118.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-ec2": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-lambda": "1.118.0",
+        "@aws-cdk/aws-s3": "1.118.0",
+        "@aws-cdk/cloud-assembly-schema": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
+        "@aws-cdk/region-info": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-events": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.131.0.tgz",
-      "integrity": "sha512-0ADuYN6m51Z4/u0qmao8106u64Fnvjr/nBM7vwP6ZKIrsh7qV5Xq10Btbg5m7nDU2w73L5fFSBfaKz3IJG/gPQ==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.118.0.tgz",
+      "integrity": "sha512-4/D4+BAYRXFBQ1XIHwDGf2Yn27lLTNeK/K57HGYZRiTEDqthwIPQP+bvUV3jJ246Yd6QUKYWbUMN0xbq6EkLHQ==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-iam": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.131.0.tgz",
-      "integrity": "sha512-DvqfbdtSy1K2/+ga5X1CTdPv9EzPR5/eNYxrwugcCJZW/Ll7DeF5TKAlfA9e0/bev00T9aWQYSDipVji60fS9g==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.118.0.tgz",
+      "integrity": "sha512-1AhnGWclYnZmuO/A5EY37atd/xYssC0EB/wzxQz/nwsSoKIKguTmNoK7ZWY/b2UJyqWFSSQII7DCVDT3P583jQ==",
       "requires": {
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/region-info": "1.131.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/region-info": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-kinesis": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesis/-/aws-kinesis-1.131.0.tgz",
-      "integrity": "sha512-4Wp8wHt5dxugRhsEuItedk+zutJhqPnf+d7kBerQpV9zTz6VoroQfDf7TOR/0HvJ6zQsXzfrHfg72V9SF3JeLQ==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesis/-/aws-kinesis-1.118.0.tgz",
+      "integrity": "sha512-een/6skCnLMBSmp0/HNss5LkqQzaNYJGlUrPdwW+jMFWs9MjAB5S8N9a3I2T+hvRfS/pBDLWp3aA8EB6SVxgYQ==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/aws-logs": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/aws-logs": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-kms": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.131.0.tgz",
-      "integrity": "sha512-dqM1qMXhZbUAHJ0k3fdIIvGQQ7o8rgoSVhBtqlKD35HnCe9kDOBaf+ZxrDPmAtOlN9VHOtstnyg9g2z9prYBXQ==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.118.0.tgz",
+      "integrity": "sha512-BrtkooxyKUDCQPPI8uheS/RYgBGNB6Dtoneky7DviotMcgLBgl7emHzi9K6H4p/ZjQqTpRqY0KGjximmS1BMjw==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/cloud-assembly-schema": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-lambda": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.131.0.tgz",
-      "integrity": "sha512-yTk/GL6WzJdgyjTUdgnOrtMvrhzJfdRQI5zKeF9ybvwKFrXB9vjgLsg7vm4awZKYqUi1PEbs2cYFwjdSiUe1Rg==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.118.0.tgz",
+      "integrity": "sha512-OfxFdRG3wVFSWfCktc0oHx7CnVOG+HUvA6QStrMWnlEBHE8aRR6zFSUK11CbuDe8/bLrJqs9N5QvOLWk7j2kRA==",
       "requires": {
-        "@aws-cdk/aws-applicationautoscaling": "1.131.0",
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-codeguruprofiler": "1.131.0",
-        "@aws-cdk/aws-ec2": "1.131.0",
-        "@aws-cdk/aws-ecr": "1.131.0",
-        "@aws-cdk/aws-ecr-assets": "1.131.0",
-        "@aws-cdk/aws-efs": "1.131.0",
-        "@aws-cdk/aws-events": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/aws-logs": "1.131.0",
-        "@aws-cdk/aws-s3": "1.131.0",
-        "@aws-cdk/aws-s3-assets": "1.131.0",
-        "@aws-cdk/aws-signer": "1.131.0",
-        "@aws-cdk/aws-sqs": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
-        "@aws-cdk/region-info": "1.131.0",
+        "@aws-cdk/aws-applicationautoscaling": "1.118.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-codeguruprofiler": "1.118.0",
+        "@aws-cdk/aws-ec2": "1.118.0",
+        "@aws-cdk/aws-ecr": "1.118.0",
+        "@aws-cdk/aws-ecr-assets": "1.118.0",
+        "@aws-cdk/aws-efs": "1.118.0",
+        "@aws-cdk/aws-events": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/aws-logs": "1.118.0",
+        "@aws-cdk/aws-s3": "1.118.0",
+        "@aws-cdk/aws-s3-assets": "1.118.0",
+        "@aws-cdk/aws-signer": "1.118.0",
+        "@aws-cdk/aws-sqs": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
+        "@aws-cdk/region-info": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-logs": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.131.0.tgz",
-      "integrity": "sha512-9URP82evwM395RAKHbVi1/umiDwBWXtqG71OxFsQlpKQ1GQ6nQNSRnCSPznT3b1DPlKLvvCPRCpRZMQMg0i7mg==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.118.0.tgz",
+      "integrity": "sha512-lkmL49Z+p0uv2dSJvOoOteW917G/rq3AdG8DSG9uNu5A4YJBRhNZLmdddtCkwt6agS6/06k+NKt07qrro3vLZw==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/aws-s3-assets": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/aws-s3-assets": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-route53": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.131.0.tgz",
-      "integrity": "sha512-d5WBijV2+vbxNALcpZTUKXLb37e06mMh0oGzC//k853XHOqZ/vntft+XeQHdOUJHZW939W28Oy9wRGgGUny5Ww==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.118.0.tgz",
+      "integrity": "sha512-TvqmzP8PmsMhFNg+TGBbiW/t5gk6ftQLn2bSGWsPyDEjJw8nu1uh/GX0J1UuxXQiLTuMv3w6xezru+wXsOlb0g==",
       "requires": {
-        "@aws-cdk/aws-ec2": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-logs": "1.131.0",
-        "@aws-cdk/cloud-assembly-schema": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/custom-resources": "1.131.0",
+        "@aws-cdk/aws-ec2": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-logs": "1.118.0",
+        "@aws-cdk/cloud-assembly-schema": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/custom-resources": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-s3": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.131.0.tgz",
-      "integrity": "sha512-LODuV5tPmrH7nPhb2mlyfprFnE6obsF5CKRuWFnE1zCq/46Wuy3VSjb8ON+ukxx7uOBbeJhoaclW1oKPIL3PwA==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.118.0.tgz",
+      "integrity": "sha512-fjhqb+d0uCsJtByKRFU/If2mg3qTqEfKfbamhDfmPyeDGxUoaJnAh5CNv1cSE5otdOeQGKozhCqlK45eK2FrPg==",
       "requires": {
-        "@aws-cdk/aws-events": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
+        "@aws-cdk/aws-events": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-s3-assets": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.131.0.tgz",
-      "integrity": "sha512-fqWxYDK5PITwu3nji60qbKBKbMmrxvUm0fsRkClNNcXQ+cBP3G1s9VdyArAkXCPgVEHjEwcVKh+VrD35zvrTwQ==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.118.0.tgz",
+      "integrity": "sha512-E4Oa5YEsusZBSzdnFtHNeJbGALCvMxfm1tBVxqYhvt6+e61eCc12m3fsCkwwaye1fGTQmYaTr1l4Ft9/psXnPQ==",
       "requires": {
-        "@aws-cdk/assets": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/aws-s3": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
+        "@aws-cdk/assets": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/aws-s3": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-signer": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.131.0.tgz",
-      "integrity": "sha512-tfqcwecMqShOsi5/2nnEtR8LD0lXrzrYbeuuhzEKhw8KSTBv8xWtsRb6pmvnLIlQJOb5p7ry1KuRPg5P4o8atg==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.118.0.tgz",
+      "integrity": "sha512-0rZTTRbNzpBBhb8xTQeHXQgRGhcJeYCvUsxb2rOElRW0mlCD0//QdtG5QhMi+3BrYe5Lu6BAPZBgBh+Sd1o6Bw==",
       "requires": {
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-sns": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.131.0.tgz",
-      "integrity": "sha512-zEiRbj16J7gHD6MUAbpLMz/ZpxGtPFZAStm+8S3y2mLIz+fjOW8S7c5sSsph1zzK6Naxv4lsKQtlFEEAth7zQg==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.118.0.tgz",
+      "integrity": "sha512-wKSgTqMltWJo7DSsDIiCAvNyOLN28vn/BqG6e+mFcHGZapduUb1pjqvMwH9LOs+Lj9NcWsRSn+bjYEV1+cN3Zg==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-codestarnotifications": "1.131.0",
-        "@aws-cdk/aws-events": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/aws-sqs": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-codestarnotifications": "1.118.0",
+        "@aws-cdk/aws-events": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/aws-sqs": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-sqs": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.131.0.tgz",
-      "integrity": "sha512-5Pl8neqzO3T2VmIIc2Dov/QF23YJyMccYE6pIrICGqdsYnGj/jTnsRRqKHLlEKjztEsHeHdX51+9T3Q/2yIGVA==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.118.0.tgz",
+      "integrity": "sha512-4QPA/kNS73L5si3t3P42V7ctDp1fOzKPluF8MSD9Bgvkb2k5HBTpW/KjTONNrJaMSBUE01uZ+cPkIwgnNSf2dA==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-cloudwatch": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-ssm": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.131.0.tgz",
-      "integrity": "sha512-jA8lZy+LH8a5qkIAfqWz2qOepO2r7ihCsBrcCtVMC+D3lE1KkJ1JrgrPvqmMcm1MxhhQs8H2n5pNrhmR4qZ6Jw==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.118.0.tgz",
+      "integrity": "sha512-AUoCWjvCrWpF0K4pE2JHmb/ktr6W3u01OcGs8N5gPBlhXU8kBci4GJ0jH6T3TQ8RMZzNoNEJmrM/sw1jY7h1Cw==",
       "requires": {
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-kms": "1.131.0",
-        "@aws-cdk/cloud-assembly-schema": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-kms": "1.118.0",
+        "@aws-cdk/cloud-assembly-schema": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/cloud-assembly-schema": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.131.0.tgz",
-      "integrity": "sha512-azF69hqd3YvwxBVUZ6a1e++iENo+bSDSk0lqYLcN4EXWsXzjPRgoC39jj3lLPqsoJrCq0AA1M+bS9Qhl0RuUJw==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.118.0.tgz",
+      "integrity": "sha512-Bmxftbl/SScafJJio2+hQiNdPqvydouzqGtW9xdtL0/T8m5pi7nmV4PG+wCafPGEJA66A56b5CGk/svL/CSj4g==",
       "requires": {
         "jsonschema": "^1.4.0",
         "semver": "^7.3.5"
@@ -444,58 +433,58 @@
       "dependencies": {
         "jsonschema": {
           "version": "1.4.0",
-          "bundled": true
+          "resolved": false
         },
         "lru-cache": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.3.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         }
       }
     },
     "@aws-cdk/core": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.131.0.tgz",
-      "integrity": "sha512-X48H0yvF1fBeL8Dz6pR8rqCHCB8aI7xXTrYWbHnR9J7xwf4r1Tkotx9PNUqseSjzsm0Z8vTUkxiuwYPI17XtSQ==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.118.0.tgz",
+      "integrity": "sha512-AYUMUn2S05YrbpBkd7YfwzAT0zCAUdLFq1KUpg9y/pWpqGX883/JSQmT6ygoXxE5gVCaziUxpFxToFWE96SE/g==",
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
-        "@aws-cdk/region-info": "1.131.0",
+        "@aws-cdk/cloud-assembly-schema": "1.118.0",
+        "@aws-cdk/cx-api": "1.118.0",
+        "@aws-cdk/region-info": "1.118.0",
         "@balena/dockerignore": "^1.0.2",
         "constructs": "^3.3.69",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.1.9",
+        "ignore": "^5.1.8",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
         "@balena/dockerignore": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "at-least-node": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -503,11 +492,11 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false
         },
         "fs-extra": {
           "version": "9.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
@@ -516,16 +505,16 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.8",
-          "bundled": true
+          "version": "4.2.6",
+          "resolved": false
         },
         "ignore": {
-          "version": "5.1.9",
-          "bundled": true
+          "version": "5.1.8",
+          "resolved": false
         },
         "jsonfile": {
           "version": "6.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
@@ -533,65 +522,65 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "universalify": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         }
       }
     },
     "@aws-cdk/custom-resources": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.131.0.tgz",
-      "integrity": "sha512-Z4h53DU9EvXh0OttiZ1B+UFm5Bjr0q4TKM0i/KC+laWK9BwmOT0UWKR7AslUylq2X2zTwQpiUKiTgwnYFKFkeQ==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.118.0.tgz",
+      "integrity": "sha512-0IHQjarO51++d/V/9nBxo3AV+wCeUmL669RPMwScSm92vymtBoNa3SZ/YbAGqOnWkdzpeZsAD+zWU8ShcMxl/g==",
       "requires": {
-        "@aws-cdk/aws-cloudformation": "1.131.0",
-        "@aws-cdk/aws-ec2": "1.131.0",
-        "@aws-cdk/aws-iam": "1.131.0",
-        "@aws-cdk/aws-lambda": "1.131.0",
-        "@aws-cdk/aws-logs": "1.131.0",
-        "@aws-cdk/aws-sns": "1.131.0",
-        "@aws-cdk/core": "1.131.0",
+        "@aws-cdk/aws-cloudformation": "1.118.0",
+        "@aws-cdk/aws-ec2": "1.118.0",
+        "@aws-cdk/aws-iam": "1.118.0",
+        "@aws-cdk/aws-lambda": "1.118.0",
+        "@aws-cdk/aws-logs": "1.118.0",
+        "@aws-cdk/aws-sns": "1.118.0",
+        "@aws-cdk/core": "1.118.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/cx-api": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.131.0.tgz",
-      "integrity": "sha512-MlgzsOvlyU6uyQJpZclcvoDQKqhIQwagObCiXM+/IfmtccURcIPLzTA68/8s2t9S7Y9KUFoymRSOjLps8ghJ8Q==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.118.0.tgz",
+      "integrity": "sha512-pNeuxHPmJjUvLIr89J4uMt8c2JkiuclgZ1JBilot+dFD8GAb0RhxhtfSnA3scOB/Lnnd0Qf4UQhKsd5vqEdqAA==",
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.131.0",
+        "@aws-cdk/cloud-assembly-schema": "1.118.0",
         "semver": "^7.3.5"
       },
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.3.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         }
       }
     },
     "@aws-cdk/region-info": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.131.0.tgz",
-      "integrity": "sha512-5reys4utb3fjKD7Zqf8AelAw7+WTxqJpdDd5mzXeTQvRYPVT5nLFl+K8by0vIg9Gh/fss6OIA22/+CErmoQRtA=="
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.118.0.tgz",
+      "integrity": "sha512-7hudA/zfCsDw0DIDu/Cc4+UJjW6aC0y4Mp7AmxlxkziXIEZi3KvSXwR2IBmKV+pSWMvMZYTiPJIgLLqB+moFgQ=="
     },
     "@babel/code-frame": {
       "version": "7.16.0",
@@ -659,14 +648,14 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz",
-      "integrity": "sha512-S7iaOT1SYlqK0sQaCi21RX4+13hmdmnxIEAnQUB/eh7GeAnRjOUgTYpLkUOiRXzD+yog1JxP0qyAQZ7ZxVxLVg==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
+      "integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.16.0",
         "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.17.5",
         "semver": "^6.3.0"
       }
     },
@@ -791,13 +780,13 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.0.tgz",
-      "integrity": "sha512-dVRM0StFMdKlkt7cVcGgwD8UMaBfWJHl3A83Yfs8GQ3MO0LHIIIMvK7Fa0RGOGUQ10qikLaX6D7o5htcQWgTMQ==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.3.tgz",
+      "integrity": "sha512-Xn8IhDlBPhvYTvgewPKawhADichOsbkZuzN7qz2BusOM0brChsyXMDJvldWaYMMUNiCQdQzNEioXTp3sC8Nt8w==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
+        "@babel/traverse": "^7.16.3",
         "@babel/types": "^7.16.0"
       }
     },
@@ -865,9 +854,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
-      "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.3.tgz",
+      "integrity": "sha512-dcNwU1O4sx57ClvLBVFbEgx0UZWfd0JQX5X6fxFRCLHelFBGXFfSz6Y0FAq2PEwUqlqLkdVjVr4VASEOuUnLJw==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -990,9 +979,9 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
-      "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.0",
@@ -1000,7 +989,7 @@
         "@babel/helper-function-name": "^7.16.0",
         "@babel/helper-hoist-variables": "^7.16.0",
         "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/parser": "^7.16.0",
+        "@babel/parser": "^7.16.3",
         "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -1529,21 +1518,20 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.131.0.tgz",
-      "integrity": "sha512-tDP9JPsOhsGcXKYwrwo8XVxDdveaYs/4if3NWSTCCoLHvNPLjnID+OPHnDLbbs8PCxSl/1oT6TvASZ/CAtMdyg==",
+      "version": "2.0.0-rc.27",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.0.0-rc.27.tgz",
+      "integrity": "sha512-Lks7tzAfV7vE1PJGxrDW7Cd9yqmjcV4IpaScn3VXTGPirX5ak4wy/oDAEQajymAawt5phYcbGEdPrh6cDJBgVQ==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.131.0",
-        "@aws-cdk/cloudformation-diff": "1.131.0",
-        "@aws-cdk/cx-api": "1.131.0",
-        "@aws-cdk/region-info": "1.131.0",
-        "@jsii/check-node": "1.42.0",
+        "@aws-cdk/cloud-assembly-schema": "2.0.0-rc.27",
+        "@aws-cdk/cloudformation-diff": "2.0.0-rc.27",
+        "@aws-cdk/cx-api": "2.0.0-rc.27",
+        "@aws-cdk/region-info": "2.0.0-rc.27",
+        "@jsii/check-node": "1.40.0",
         "archiver": "^5.3.0",
         "aws-sdk": "^2.979.0",
         "camelcase": "^6.2.0",
-        "cdk-assets": "1.131.0",
-        "chokidar": "^3.5.2",
+        "cdk-assets": "2.0.0-rc.27",
         "colors": "^1.4.0",
         "decamelize": "^5.0.1",
         "fs-extra": "^9.1.0",
@@ -1562,9 +1550,9 @@
       },
       "dependencies": {
         "@aws-cdk/cfnspec": {
-          "version": "1.131.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.131.0.tgz",
-          "integrity": "sha512-M933CKAFKLaA49Sxz9QPZFD2L404DNNsEum8d4GISU2IJQg5Ud/AIeJ+55NxE3Gx6AqG1Ih6JnhlxP07bamglQ==",
+          "version": "2.0.0-rc.27",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-2.0.0-rc.27.tgz",
+          "integrity": "sha512-5NMAotyYa8ZJUseHhrwZDb5ax2g9UCLBcCo+diWIxcIjFtdkdYKT3yFRgbh8LRKp3fdn/ubIddNblZoD0VcSsg==",
           "dev": true,
           "requires": {
             "fs-extra": "^9.1.0",
@@ -1572,9 +1560,9 @@
           }
         },
         "@aws-cdk/cloud-assembly-schema": {
-          "version": "1.131.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.131.0.tgz",
-          "integrity": "sha512-azF69hqd3YvwxBVUZ6a1e++iENo+bSDSk0lqYLcN4EXWsXzjPRgoC39jj3lLPqsoJrCq0AA1M+bS9Qhl0RuUJw==",
+          "version": "2.0.0-rc.27",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-2.0.0-rc.27.tgz",
+          "integrity": "sha512-1w4Htcu4zkSNkd2TQzMYnpGHNYYyPhIkoi4d03TMAX74NqF4puj/I5AQuPB7nKFLUa2G8lAZXAUb0DqukdYuLA==",
           "dev": true,
           "requires": {
             "jsonschema": "^1.4.0",
@@ -1582,12 +1570,12 @@
           }
         },
         "@aws-cdk/cloudformation-diff": {
-          "version": "1.131.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.131.0.tgz",
-          "integrity": "sha512-g91/Tsz8g8aa9oVAvzs6FSrzf5Ss5r04H3U4M5WbUjLBfMttaNOQy/jcgtAjd98U5RHY9d4RdWsB81J76GcXRg==",
+          "version": "2.0.0-rc.27",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.0.0-rc.27.tgz",
+          "integrity": "sha512-sTedKxLATf9UZOwe3fTp5JJOWOWV6B1+7Gl8CNYViUB7tKWUdIbNn1AkBNtM4fYifXinv2c3P0ekCTcPZEU6Hw==",
           "dev": true,
           "requires": {
-            "@aws-cdk/cfnspec": "1.131.0",
+            "@aws-cdk/cfnspec": "2.0.0-rc.27",
             "@types/node": "^10.17.60",
             "colors": "^1.4.0",
             "diff": "^5.0.0",
@@ -1597,25 +1585,25 @@
           }
         },
         "@aws-cdk/cx-api": {
-          "version": "1.131.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.131.0.tgz",
-          "integrity": "sha512-MlgzsOvlyU6uyQJpZclcvoDQKqhIQwagObCiXM+/IfmtccURcIPLzTA68/8s2t9S7Y9KUFoymRSOjLps8ghJ8Q==",
+          "version": "2.0.0-rc.27",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-2.0.0-rc.27.tgz",
+          "integrity": "sha512-JP9sFRRknI+ijGhIDnATsspGPXXMImXm6YX9P62Jb2Fp43O6dALYNVTIvaK9u4H0iwdVQ3dbJYjJWZ5FkKghaQ==",
           "dev": true,
           "requires": {
-            "@aws-cdk/cloud-assembly-schema": "1.131.0",
+            "@aws-cdk/cloud-assembly-schema": "2.0.0-rc.27",
             "semver": "^7.3.5"
           }
         },
         "@aws-cdk/region-info": {
-          "version": "1.131.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.131.0.tgz",
-          "integrity": "sha512-5reys4utb3fjKD7Zqf8AelAw7+WTxqJpdDd5mzXeTQvRYPVT5nLFl+K8by0vIg9Gh/fss6OIA22/+CErmoQRtA==",
+          "version": "2.0.0-rc.27",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-2.0.0-rc.27.tgz",
+          "integrity": "sha512-YXP7dXPyqlIkuFY3QOejME5FJQBDEYMsisTsF8DNw1sJ+RCC1wGX6RjR6IkVX5pbegCBY1O7T+u0phiIJ36uZQ==",
           "dev": true
         },
         "@jsii/check-node": {
-          "version": "1.42.0",
-          "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.42.0.tgz#10dd84fbefa020344c9574079361c1a18754872a",
-          "integrity": "sha512-URX4s0iOmuxbERL2rO10JlwedYbAT/3vM2HqswgjtJUbZTFgHsmg+Tzh3JglJzKuCg8Xm4m6CP4UlFMPqPRcqA==",
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.40.0.tgz#49882a61ad1b3a37cd35c35fa1a2301955f1c058",
+          "integrity": "sha512-rk0hFXxFQR8rDGUfsZT9ua6OufOpnLQWsNFyFU86AvpoKQ0ciw2KlGdWs7OYFnzPq8sQGhSS+iuBrUboaHW3jg==",
           "dev": true,
           "requires": {
             "chalk": "^4.1.2",
@@ -1668,16 +1656,6 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
-          }
-        },
-        "anymatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716",
-          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-          "dev": true,
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
           }
         },
         "archiver": {
@@ -1746,9 +1724,9 @@
           "dev": true
         },
         "async": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz#2eb7671034bb2194d45d30e31e24ec7e7f9670cd",
-          "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz#d3274ec66d107a47476a4c49136aacdb00665fc8",
+          "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==",
           "dev": true
         },
         "at-least-node": {
@@ -1758,9 +1736,9 @@
           "dev": true
         },
         "aws-sdk": {
-          "version": "2.1020.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1020.0.tgz#91fee48f3897e21b0fa6fbd066ea716ac2f0957d",
-          "integrity": "sha512-cCFLGRfzJn0whOioljFjcFpQTXWB4PTdVnrpNhX2R687W3Yz6WriHxHqIxVnIke1yp9twU00z4kW522U809l0g==",
+          "version": "2.1006.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1006.0.tgz#fc2f7e267d19a6297f732e19449461bb944682af",
+          "integrity": "sha512-lwXAy706+1HVQqMnHaahdeBZZbdu6TWrtTY0ydeG0qanwldTFNMLczwnETTZWYsqNAU+wjl1VzmFdMO4gePLNQ==",
           "dev": true,
           "requires": {
             "buffer": "4.9.2",
@@ -1819,12 +1797,6 @@
           "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
           "dev": true
         },
-        "binary-extensions": {
-          "version": "2.2.0",
-          "resolved": "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d",
-          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-          "dev": true
-        },
         "bl": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a",
@@ -1844,15 +1816,6 @@
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
-          }
-        },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
           }
         },
         "buffer": {
@@ -1890,17 +1853,17 @@
           "dev": true
         },
         "cdk-assets": {
-          "version": "1.131.0",
-          "resolved": "https://registry.npmjs.org/cdk-assets/-/cdk-assets-1.131.0.tgz",
-          "integrity": "sha512-Fx8moMYnAMrmQIjRVlNajg+OouNRSsR1XeY+T7o521sViYLZ4gbwal5jzKNOeVVyc6neXi6iK1qSumKzm+i9og==",
+          "version": "2.0.0-rc.27",
+          "resolved": "https://registry.npmjs.org/cdk-assets/-/cdk-assets-2.0.0-rc.27.tgz",
+          "integrity": "sha512-HnXU+V59QvuzEBfcbcD78e5xlKzxVVnvWB2nwX1cfFeWPqOgwRiWNfBoDwResPC2HW8NmjoD6T/jXowcZ0TzDQ==",
           "dev": true,
           "requires": {
-            "@aws-cdk/cloud-assembly-schema": "1.131.0",
-            "@aws-cdk/cx-api": "1.131.0",
+            "@aws-cdk/cloud-assembly-schema": "2.0.0-rc.27",
+            "@aws-cdk/cx-api": "2.0.0-rc.27",
             "archiver": "^5.3.0",
             "aws-sdk": "^2.848.0",
             "glob": "^7.2.0",
-            "mime": "^2.6.0",
+            "mime": "^2.5.2",
             "yargs": "^16.2.0"
           }
         },
@@ -1919,22 +1882,6 @@
           "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667",
           "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
           "dev": true
-        },
-        "chokidar": {
-          "version": "3.5.2",
-          "resolved": "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75",
-          "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-          "dev": true,
-          "requires": {
-            "anymatch": "~3.1.2",
-            "braces": "~3.0.2",
-            "fsevents": "~2.3.2",
-            "glob-parent": "~5.1.2",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.6.0"
-          }
         },
         "cli-color": {
           "version": "0.1.7",
@@ -2184,15 +2131,6 @@
           "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
           "dev": true
         },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad",
@@ -2315,15 +2253,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
         "graceful-fs": {
           "version": "4.2.8",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a",
@@ -2413,46 +2342,16 @@
           "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
           "dev": true
         },
-        "is-binary-path": {
-          "version": "2.1.0",
-          "resolved": "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09",
-          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-          "dev": true,
-          "requires": {
-            "binary-extensions": "^2.0.0"
-          }
-        },
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
         "isarray": {
@@ -2501,9 +2400,9 @@
           "dev": true
         },
         "lazystream": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz#494c831062f1f9408251ec44db1cba29242a2638",
-          "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4",
+          "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
           "dev": true,
           "requires": {
             "readable-stream": "^2.0.5"
@@ -2599,9 +2498,9 @@
           }
         },
         "mime": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367",
-          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
           "dev": true
         },
         "minimatch": {
@@ -2692,12 +2591,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "picomatch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972",
-          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
           "dev": true
         },
         "prelude-ls": {
@@ -2834,15 +2727,6 @@
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
-          }
-        },
-        "readdirp": {
-          "version": "3.6.0",
-          "resolved": "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7",
-          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-          "dev": true,
-          "requires": {
-            "picomatch": "^2.2.1"
           }
         },
         "require-directory": {
@@ -3015,15 +2899,6 @@
             "readable-stream": "^3.1.1"
           }
         },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        },
         "toidentifier": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553",
@@ -3097,9 +2972,9 @@
           "dev": true
         },
         "vm2": {
-          "version": "3.9.5",
-          "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz#5288044860b4bbace443101fcd3bddb2a0aa2496",
-          "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng==",
+          "version": "3.9.4",
+          "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.4.tgz#2e118290fefe7bd8ea09ebe2f5faf53730dbddaa",
+          "integrity": "sha512-sOdharrJ7KEePIpHekiWaY1DwgueuiBeX/ZBJUPgETsVlJsXuEx0K0/naATq2haFvJrvZnRiORQRubR0b7Ye6g==",
           "dev": true
         },
         "word-wrap": {
@@ -3210,6 +3085,202 @@
             "compress-commons": "^4.1.0",
             "readable-stream": "^3.6.0"
           }
+        }
+      }
+    },
+    "aws-cdk-lib": {
+      "version": "2.0.0-rc.27",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.0.0-rc.27.tgz",
+      "integrity": "sha512-yKiXhqvSgPWr8yeatL19J38bmrnzLQfuuSZbZwNEWjFj9XArj+U1b7K1EXPUyPYkC7JKv2AIB0UuYeiwcc00aA==",
+      "requires": {
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "colors": "^1.4.0",
+        "diff": "^5.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.1.8",
+        "jsonschema": "^1.4.0",
+        "minimatch": "^3.0.4",
+        "punycode": "^2.1.1",
+        "semver": "^7.3.5",
+        "string-width": "^4.2.3",
+        "table": "^6.7.2",
+        "yaml": "1.10.2"
+      },
+      "dependencies": {
+        "@balena/dockerignore": {
+          "version": "1.0.2"
+        },
+        "ajv": {
+          "version": "8.6.3",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1"
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0"
+        },
+        "at-least-node": {
+          "version": "1.0.0"
+        },
+        "balanced-match": {
+          "version": "1.0.2"
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "case": {
+          "version": "1.6.3"
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4"
+        },
+        "colors": {
+          "version": "1.4.0"
+        },
+        "concat-map": {
+          "version": "0.0.1"
+        },
+        "diff": {
+          "version": "5.0.0"
+        },
+        "emoji-regex": {
+          "version": "8.0.0"
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3"
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.8"
+        },
+        "ignore": {
+          "version": "5.1.8"
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0"
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0"
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonschema": {
+          "version": "1.4.0"
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0"
+        },
+        "lodash.truncate": {
+          "version": "4.4.2"
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1"
+        },
+        "require-from-string": {
+          "version": "2.0.2"
+        },
+        "semver": {
+          "version": "7.3.5",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "table": {
+          "version": "6.7.2",
+          "requires": {
+            "ajv": "^8.0.1",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.truncate": "^4.4.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0"
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0"
+        },
+        "yaml": {
+          "version": "1.10.2"
         }
       }
     },
@@ -3452,9 +3523,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001278",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001278.tgz",
-      "integrity": "sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg==",
+      "version": "1.0.30001279",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
       "dev": true
     },
     "capture-exit": {
@@ -3467,14 +3538,14 @@
       }
     },
     "cdk-dynamo-table-viewer": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cdk-dynamo-table-viewer/-/cdk-dynamo-table-viewer-3.1.2.tgz",
-      "integrity": "sha512-BPJqYj/CFOE02ZPx3bdxj/yAvAPH0TJHPinJGGX1hUtO7x5pgI7z4svnSsyfCz8UazMTKQJLXh7Rb2aXgBAuJQ==",
+      "version": "0.1.60",
+      "resolved": "https://registry.npmjs.org/cdk-dynamo-table-viewer/-/cdk-dynamo-table-viewer-0.1.60.tgz",
+      "integrity": "sha512-ocHaCoiASRFO0b8u+h2Ay7m7HZvP3FBtJ9ZbzrEmfwWgrBTmrZgTC7+CLHme+sFOnYOGpQbjvqKMV3HhtUFv6A==",
       "requires": {
-        "@aws-cdk/aws-apigateway": "^1.20.0",
-        "@aws-cdk/aws-dynamodb": "^1.20.0",
-        "@aws-cdk/aws-lambda": "^1.20.0",
-        "@aws-cdk/core": "^1.20.0"
+        "@aws-cdk/aws-apigateway": "^1.106.0",
+        "@aws-cdk/aws-dynamodb": "^1.106.0",
+        "@aws-cdk/aws-lambda": "^1.106.0",
+        "@aws-cdk/core": "^1.106.0"
       }
     },
     "chalk": {
@@ -3598,9 +3669,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "3.3.161",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.161.tgz",
-      "integrity": "sha512-/27vW3fo0iyb3py4vKI1BduEYmv8vv8uJgLXvI+5F0Jbnn0/E+As2wkGMa7bumhzCd0Ckv/USkAXstGYVXTYQA=="
+      "version": "3.3.124",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.124.tgz",
+      "integrity": "sha512-Jj/I48WUvCUudNOJYslOXCFgPK+rg8x0JQdUpfUHh1YA2/uE9LheTHgm+yMg9BGlrfgulAUIc8bg3eUJlVNK0g=="
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -3788,9 +3859,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.891",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.891.tgz",
-      "integrity": "sha512-3cpwR82QkIS01CN/dup/4Yr3BiOiRLlZlcAFn/5FbNCunMO9ojqDgEP9JEo1QNLflu3pEnPWve50gHOEKc7r6w==",
+      "version": "1.3.893",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz",
+      "integrity": "sha512-ChtwF7qB03INq1SyMpue08wc6cve+ktj2UC/Y7se9vB+JryfzziJeYwsgb8jLaCA5GMkHCdn5M62PfSMWhifZg==",
       "dev": true
     },
     "emittery": {
@@ -5297,18 +5368,18 @@
       }
     },
     "mime-db": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.50.0"
+        "mime-db": "1.51.0"
       }
     },
     "mimic-fn": {

--- a/code/typescript/main-workshop/package.json
+++ b/code/typescript/main-workshop/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0-rc.27",
-    "cdk-dynamo-table-viewer": "^0.1.60"
+    "constructs": "^10.0.5",
+    "cdk-dynamo-table-viewer": "^0.2.0"
   }
 }

--- a/code/typescript/main-workshop/package.json
+++ b/code/typescript/main-workshop/package.json
@@ -12,21 +12,14 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.10",
-    "@types/node": "10.17.27",
+    "@types/node": "^16.6.1",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "@types/node": "^16.6.1",
-    "aws-cdk": "^1.131.0",
+    "aws-cdk": "^2.0.0-rc.27",
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "^1.131.0",
-    "@aws-cdk/aws-dynamodb": "^1.131.0",
-    "@aws-cdk/aws-lambda": "^1.131.0",
-    "@aws-cdk/aws-sns": "^1.131.0",
-    "@aws-cdk/aws-sqs": "^1.131.0",
-    "@aws-cdk/core": "^1.131.0",
-    "@aws-cdk/cx-api": "^1.131.0",
-    "cdk-dynamo-table-viewer": "3.1.2"
+    "aws-cdk-lib": "^2.0.0-rc.27",
+    "cdk-dynamo-table-viewer": "^0.1.60"
   }
 }

--- a/code/typescript/pipelines-workshop/bin/cdk-workshop.ts
+++ b/code/typescript/pipelines-workshop/bin/cdk-workshop.ts
@@ -1,5 +1,5 @@
-import {App} from '@aws-cdk/core';
-import {WorkshopPipelineStack} from "../lib/pipeline-stack";
+import { App } from 'aws-cdk-lib';
+import { WorkshopPipelineStack } from "../lib/pipeline-stack";
 
 const app = new App();
 new WorkshopPipelineStack(app, 'CdkWorkshopPipelineStack');

--- a/code/typescript/pipelines-workshop/cdk.json
+++ b/code/typescript/pipelines-workshop/cdk.json
@@ -1,18 +1,9 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/cdk-workshop.ts",
   "context": {
-    "@aws-cdk/core:newStyleStackSynthesis": true,
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
-    "aws-cdk:enableDiffNoFail": true,
     "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
     "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
   }

--- a/code/typescript/pipelines-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/pipelines-workshop/lib/cdk-workshop-stack.ts
@@ -1,4 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import { HitCounter } from './hitcounter';
@@ -8,7 +9,7 @@ export class CdkWorkshopStack extends cdk.Stack {
   public readonly hcViewerUrl: cdk.CfnOutput;
   public readonly hcEndpoint: cdk.CfnOutput;
 
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {

--- a/code/typescript/pipelines-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/pipelines-workshop/lib/cdk-workshop-stack.ts
@@ -1,6 +1,6 @@
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as apigw from '@aws-cdk/aws-apigateway';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 

--- a/code/typescript/pipelines-workshop/lib/hitcounter.ts
+++ b/code/typescript/pipelines-workshop/lib/hitcounter.ts
@@ -1,4 +1,3 @@
-import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
@@ -24,7 +23,7 @@ export class HitCounter extends Construct {
   /** the hit counter table */
   public readonly table: dynamodb.Table;
 
-  constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
+  constructor(scope: Construct, id: string, props: HitCounterProps) {
     super(scope, id);
 
     const table = new dynamodb.Table(this, 'Hits', {

--- a/code/typescript/pipelines-workshop/lib/hitcounter.ts
+++ b/code/typescript/pipelines-workshop/lib/hitcounter.ts
@@ -1,6 +1,8 @@
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as dynamodb from '@aws-cdk/aws-dynamodb';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
+
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
@@ -15,7 +17,7 @@ export interface HitCounterProps {
   readCapacity?: number;
 }
 
-export class HitCounter extends cdk.Construct {
+export class HitCounter extends Construct {
   /** allows accessing the counter function */
   public readonly handler: lambda.Function;
 

--- a/code/typescript/pipelines-workshop/lib/pipeline-stack.ts
+++ b/code/typescript/pipelines-workshop/lib/pipeline-stack.ts
@@ -1,60 +1,61 @@
 import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import * as codecommit from 'aws-cdk-lib/aws-codecommit';
-import {WorkshopPipelineStage} from './pipeline-stage';
-import {CodeBuildStep, CodePipeline, CodePipelineSource} from "aws-cdk-lib/pipelines";
+import { WorkshopPipelineStage } from './pipeline-stage';
+import { CodeBuildStep, CodePipeline, CodePipelineSource } from "aws-cdk-lib/pipelines";
 
 export class WorkshopPipelineStack extends cdk.Stack {
-    constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
-        super(scope, id, props);
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
 
-        // This creates a new CodeCommit repository called 'WorkshopRepo'
-        const repo = new codecommit.Repository(this, 'WorkshopRepo', {
-            repositoryName: "WorkshopRepo"
-        });
+    // This creates a new CodeCommit repository called 'WorkshopRepo'
+    const repo = new codecommit.Repository(this, 'WorkshopRepo', {
+      repositoryName: "WorkshopRepo"
+    });
 
-        // The basic pipeline declaration. This sets the initial structure
-        // of our pipeline
+    // The basic pipeline declaration. This sets the initial structure
+    // of our pipeline
 
-        const pipeline = new CodePipeline(this, 'Pipeline', {
-            pipelineName: 'WorkshopPipeline',
-            synth: new CodeBuildStep('SynthStep', {
-                    input: CodePipelineSource.codeCommit(repo, 'master'),
-                    installCommands: [
-                        'npm install -g aws-cdk'
-                    ],
-                    commands: [
-                        'npm ci',
-                        'npm run build',
-                        'npx cdk synth'
-                    ]
-                }
-            )
-        });
+    const pipeline = new CodePipeline(this, 'Pipeline', {
+      pipelineName: 'WorkshopPipeline',
+      synth: new CodeBuildStep('SynthStep', {
+        input: CodePipelineSource.codeCommit(repo, 'master'),
+        installCommands: [
+          'npm install -g aws-cdk'
+        ],
+        commands: [
+          'npm ci',
+          'npm run build',
+          'npx cdk synth'
+        ]
+      }
+      )
+    });
 
-        const deploy = new WorkshopPipelineStage(this, 'Deploy');
-        const deployStage = pipeline.addStage(deploy);
+    const deploy = new WorkshopPipelineStage(this, 'Deploy');
+    const deployStage = pipeline.addStage(deploy);
 
-        deployStage.addPost(
-            new CodeBuildStep('TestViewerEndpoint', {
-                projectName: 'TestViewerEndpoint',
-                envFromCfnOutputs: {
-                    ENDPOINT_URL: deploy.hcViewerUrl
-                },
-                commands: [
-                    'curl -Ssf $ENDPOINT_URL'
-                ]
-            }),
-            new CodeBuildStep('TestAPIGatewayEndpoint', {
-                projectName: 'TestAPIGatewayEndpoint',
-                envFromCfnOutputs: {
-                    ENDPOINT_URL: deploy.hcEndpoint
-                },
-                commands: [
-                    'curl -Ssf $ENDPOINT_URL',
-                    'curl -Ssf $ENDPOINT_URL/hello',
-                    'curl -Ssf $ENDPOINT_URL/test'
-                ]
-            })
-        )
-    }
+    deployStage.addPost(
+      new CodeBuildStep('TestViewerEndpoint', {
+        projectName: 'TestViewerEndpoint',
+        envFromCfnOutputs: {
+          ENDPOINT_URL: deploy.hcViewerUrl
+        },
+        commands: [
+          'curl -Ssf $ENDPOINT_URL'
+        ]
+      }),
+      new CodeBuildStep('TestAPIGatewayEndpoint', {
+        projectName: 'TestAPIGatewayEndpoint',
+        envFromCfnOutputs: {
+          ENDPOINT_URL: deploy.hcEndpoint
+        },
+        commands: [
+          'curl -Ssf $ENDPOINT_URL',
+          'curl -Ssf $ENDPOINT_URL/hello',
+          'curl -Ssf $ENDPOINT_URL/test'
+        ]
+      })
+    )
+  }
 }

--- a/code/typescript/pipelines-workshop/lib/pipeline-stack.ts
+++ b/code/typescript/pipelines-workshop/lib/pipeline-stack.ts
@@ -1,7 +1,7 @@
-import * as cdk from '@aws-cdk/core';
-import * as codecommit from '@aws-cdk/aws-codecommit';
+import * as cdk from 'aws-cdk-lib';
+import * as codecommit from 'aws-cdk-lib/aws-codecommit';
 import {WorkshopPipelineStage} from './pipeline-stage';
-import {CodeBuildStep, CodePipeline, CodePipelineSource} from "@aws-cdk/pipelines";
+import {CodeBuildStep, CodePipeline, CodePipelineSource} from "aws-cdk-lib/pipelines";
 
 export class WorkshopPipelineStack extends cdk.Stack {
     constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {

--- a/code/typescript/pipelines-workshop/lib/pipeline-stage.ts
+++ b/code/typescript/pipelines-workshop/lib/pipeline-stage.ts
@@ -1,16 +1,17 @@
 import { CdkWorkshopStack } from './cdk-workshop-stack';
-import { Stage, CfnOutput, Construct, StageProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Stage, CfnOutput, StageProps } from 'aws-cdk-lib';
 
 export class WorkshopPipelineStage extends Stage {
-    public readonly hcViewerUrl: CfnOutput;
-    public readonly hcEndpoint: CfnOutput;
+  public readonly hcViewerUrl: CfnOutput;
+  public readonly hcEndpoint: CfnOutput;
 
-    constructor(scope: Construct, id: string, props?: StageProps) {
-        super(scope, id, props);
+  constructor(scope: Construct, id: string, props?: StageProps) {
+    super(scope, id, props);
 
-        const service = new CdkWorkshopStack(this, 'WebService');
+    const service = new CdkWorkshopStack(this, 'WebService');
 
-        this.hcEndpoint = service.hcEndpoint;
-        this.hcViewerUrl = service.hcViewerUrl;
-    }
+    this.hcEndpoint = service.hcEndpoint;
+    this.hcViewerUrl = service.hcViewerUrl;
+  }
 }

--- a/code/typescript/pipelines-workshop/lib/pipeline-stage.ts
+++ b/code/typescript/pipelines-workshop/lib/pipeline-stage.ts
@@ -1,5 +1,5 @@
 import { CdkWorkshopStack } from './cdk-workshop-stack';
-import { Stage, CfnOutput, Construct, StageProps } from '@aws-cdk/core';
+import { Stage, CfnOutput, Construct, StageProps } from 'aws-cdk-lib';
 
 export class WorkshopPipelineStage extends Stage {
     public readonly hcViewerUrl: CfnOutput;

--- a/code/typescript/pipelines-workshop/package.json
+++ b/code/typescript/pipelines-workshop/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0-rc.27",
-    "cdk-dynamo-table-viewer": "^0.1.60"
+    "constructs": "^10.0.5",
+    "cdk-dynamo-table-viewer": "^0.2.0"
   }
 }

--- a/code/typescript/pipelines-workshop/package.json
+++ b/code/typescript/pipelines-workshop/package.json
@@ -12,21 +12,11 @@
   },
   "devDependencies": {
     "@types/node": "^16.6.1",
-    "aws-cdk": "^1.131.0",
+    "aws-cdk": "^2.0.0-rc.27",
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "^1.131.0",
-    "@aws-cdk/aws-codecommit": "^1.131.0",
-    "@aws-cdk/aws-codepipeline": "^1.131.0",
-    "@aws-cdk/aws-codepipeline-actions": "^1.131.0",
-    "@aws-cdk/aws-dynamodb": "^1.131.0",
-    "@aws-cdk/aws-lambda": "^1.131.0",
-    "@aws-cdk/aws-sns": "^1.131.0",
-    "@aws-cdk/aws-sqs": "^1.131.0",
-    "@aws-cdk/core": "^1.131.0",
-    "@aws-cdk/cx-api": "^1.131.0",
-    "@aws-cdk/pipelines": "^1.131.0",
-    "cdk-dynamo-table-viewer": "3.1.2"
+    "aws-cdk-lib": "^2.0.0-rc.27",
+    "cdk-dynamo-table-viewer": "^0.1.60"
   }
 }

--- a/code/typescript/tests-workshop/bin/cdk-workshop.ts
+++ b/code/typescript/tests-workshop/bin/cdk-workshop.ts
@@ -1,4 +1,4 @@
-import { App } from '@aws-cdk/core';
+import { App } from 'aws-cdk-lib';
 import { CdkWorkshopStack } from '../lib/cdk-workshop-stack';
 
 const app = new App();

--- a/code/typescript/tests-workshop/cdk.json
+++ b/code/typescript/tests-workshop/cdk.json
@@ -1,18 +1,9 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/cdk-workshop.ts",
   "context": {
-    "@aws-cdk/core:newStyleStackSynthesis": true,
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
-    "aws-cdk:enableDiffNoFail": true,
     "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
     "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
   }

--- a/code/typescript/tests-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/tests-workshop/lib/cdk-workshop-stack.ts
@@ -1,6 +1,6 @@
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as apigw from '@aws-cdk/aws-apigateway';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 

--- a/code/typescript/tests-workshop/lib/hitcounter.ts
+++ b/code/typescript/tests-workshop/lib/hitcounter.ts
@@ -1,6 +1,7 @@
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as dynamodb from '@aws-cdk/aws-dynamodb';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
@@ -16,14 +17,14 @@ export interface HitCounterProps {
   readCapacity?: number;
 }
 
-export class HitCounter extends cdk.Construct {
+export class HitCounter extends Construct {
   /** allows accessing the counter function */
   public readonly handler: lambda.Function;
 
   /** the hit counter table */
   public readonly table: dynamodb.Table;
 
-  constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
+  constructor(scope: Construct, id: string, props: HitCounterProps) {
     if (props.readCapacity !== undefined && (props.readCapacity < 5 || props.readCapacity > 20)) {
       throw new Error('readCapacity must be greater than 5 and less than 20');
     }

--- a/code/typescript/tests-workshop/package.json
+++ b/code/typescript/tests-workshop/package.json
@@ -11,22 +11,15 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assertions": "^1.131.0",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.6.1",
-    "aws-cdk": "^1.131.0",
+    "aws-cdk": "^2.0.0-rc.27",
     "jest": "^27.0.6",
     "ts-jest": "^27.0.4",
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "^1.131.0",
-    "@aws-cdk/aws-dynamodb": "^1.131.0",
-    "@aws-cdk/aws-lambda": "^1.131.0",
-    "@aws-cdk/aws-sns": "^1.131.0",
-    "@aws-cdk/aws-sqs": "^1.131.0",
-    "@aws-cdk/core": "^1.131.0",
-    "@aws-cdk/cx-api": "^1.131.0",
-    "cdk-dynamo-table-viewer": "3.1.2"
+    "aws-cdk-lib": "^2.0.0-rc.27",
+    "cdk-dynamo-table-viewer": "^0.1.59"
   }
 }

--- a/code/typescript/tests-workshop/package.json
+++ b/code/typescript/tests-workshop/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0-rc.27",
-    "cdk-dynamo-table-viewer": "^0.1.59"
+    "constructs": "^10.0.5",
+    "cdk-dynamo-table-viewer": "^0.2.0"
   }
 }

--- a/code/typescript/tests-workshop/test/hitcounter.test.ts
+++ b/code/typescript/tests-workshop/test/hitcounter.test.ts
@@ -1,6 +1,6 @@
-import { Template, Capture } from '@aws-cdk/assertions';
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
+import { Template, Capture } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { HitCounter } from '../lib/hitcounter';
 
 test('DynamoDB Table Created', () => {

--- a/workshop/content/20-typescript/20-create-project/300-structure.md
+++ b/workshop/content/20-typescript/20-create-project/300-structure.md
@@ -37,7 +37,7 @@ Let's have a quick look at `bin/cdk-workshop.ts`:
 
 ```js
 #!/usr/bin/env node
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { CdkWorkshopStack } from '../lib/cdk-workshop-stack';
 
 const app = new cdk.App();
@@ -53,10 +53,10 @@ Open up `lib/cdk-workshop-stack.ts`. This is where the meat of our application
 is:
 
 ```ts
-import * as sns from '@aws-cdk/aws-sns';
-import * as subs from '@aws-cdk/aws-sns-subscriptions';
-import * as sqs from '@aws-cdk/aws-sqs';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
 
 export class CdkWorkshopStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {

--- a/workshop/content/20-typescript/30-hello-cdk/100-cleanup.md
+++ b/workshop/content/20-typescript/30-hello-cdk/100-cleanup.md
@@ -12,7 +12,7 @@ not going to use them in our project, so remove them from your the
 Open `lib/cdk-workshop-stack.ts` and clean it up. Eventually it should look like this:
 
 ```ts
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 
 export class CdkWorkshopStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {

--- a/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
+++ b/workshop/content/20-typescript/30-hello-cdk/200-lambda.md
@@ -44,22 +44,6 @@ Library reference](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-construct
 
 ![](./clib.png)
 
-Okay, let's use `npm install` (or in short `npm i`) to install the AWS Lambda
-module and all it's dependencies into our project:
-
-```
-npm install @aws-cdk/aws-lambda
-```
-
-Output should look like this:
-
-```
-+ @aws-cdk/aws-lambda@{{% cdkversion %}}
-updated 5 packages and audited 883208 packages in 5.455s
-```
-
-> You can safely ignore any warnings from npm about your package.json file.
-
 ## A few words about copying & pasting in this workshop
 
 In this workshop, we highly recommended to type CDK code instead of copying &
@@ -76,8 +60,8 @@ Add an `import` statement at the beginning of `lib/cdk-workshop-stack.ts`, and a
 
 
 {{<highlight ts "hl_lines=2 8-13">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 
 export class CdkWorkshopStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {

--- a/workshop/content/20-typescript/30-hello-cdk/300-apigw.md
+++ b/workshop/content/20-typescript/30-hello-cdk/300-apigw.md
@@ -13,11 +13,6 @@ mounted to the root of the API. This means that any request to any URL path will
 be proxied directly to our Lambda function, and the response from the function
 will be returned back to the user.
 
-## Install the API Gateway construct library
-
-```
-npm install @aws-cdk/aws-apigateway
-```
 
 {{% notice info %}}
 
@@ -33,9 +28,9 @@ in use.
 Going back to `lib/cdk-workshop-stack.ts`, let's define an API endpoint and associate it with our Lambda function:
 
 {{<highlight ts "hl_lines=3 16-19">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as apigw from '@aws-cdk/aws-apigateway';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
 
 export class CdkWorkshopStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {

--- a/workshop/content/20-typescript/40-hit-counter/100-api.md
+++ b/workshop/content/20-typescript/40-hit-counter/100-api.md
@@ -8,16 +8,17 @@ weight = 100
 Create a new file under `lib` called `hitcounter.ts` with the following content:
 
 ```ts
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
   downstream: lambda.IFunction;
 }
 
-export class HitCounter extends cdk.Construct {
-  constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
+export class HitCounter extends Construct {
+  constructor(scope: Construct, id: string, props: HitCounterProps) {
     super(scope, id);
 
     // TODO

--- a/workshop/content/20-typescript/40-hit-counter/300-resources.md
+++ b/workshop/content/20-typescript/40-hit-counter/300-resources.md
@@ -8,12 +8,6 @@ weight = 300
 Now, let's define the AWS Lambda function and the DynamoDB table in our
 `HitCounter` construct.
 
-As usual, we first need to install the DynamoDB construct library (we already
-have the Lambda library installed):
-
-```
-npm install @aws-cdk/aws-dynamodb
-```
 
 {{% notice info %}}
 
@@ -26,22 +20,23 @@ in use.
 
 Now, go back to `lib/hitcounter.ts` and add the following highlighted code:
 
-{{<highlight ts "hl_lines=3 12-13 18-30">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as dynamodb from '@aws-cdk/aws-dynamodb';
+{{<highlight ts "hl_lines=3 13-14 19-31">}}
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
   downstream: lambda.IFunction;
 }
 
-export class HitCounter extends cdk.Construct {
+export class HitCounter extends Construct {
 
   /** allows accessing the counter function */
   public readonly handler: lambda.Function;
 
-  constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
+  constructor(scope: Construct, id: string, props: HitCounterProps) {
     super(scope, id);
 
     const table = new dynamodb.Table(this, 'Hits', {

--- a/workshop/content/20-typescript/40-hit-counter/400-use.md
+++ b/workshop/content/20-typescript/40-hit-counter/400-use.md
@@ -9,9 +9,9 @@ Okay, our hit counter is ready. Let's use it in our app. Open `lib/cdk-workshop-
 the following highlighted code:
 
 {{<highlight ts "hl_lines=4 16-18 22">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as apigw from '@aws-cdk/aws-apigateway';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import { HitCounter } from './hitcounter';
 
 export class CdkWorkshopStack extends cdk.Stack {

--- a/workshop/content/20-typescript/40-hit-counter/600-permissions.md
+++ b/workshop/content/20-typescript/40-hit-counter/600-permissions.md
@@ -9,22 +9,23 @@ Let's give our Lambda's execution role permissions to read/write from our table.
 
 Go back to `hitcounter.ts` and add the following highlighted lines:
 
-{{<highlight ts "hl_lines=32-33">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as dynamodb from '@aws-cdk/aws-dynamodb';
+{{<highlight ts "hl_lines=33-34">}}
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
   downstream: lambda.IFunction;
 }
 
-export class HitCounter extends cdk.Construct {
+export class HitCounter extends Construct {
 
   /** allows accessing the counter function */
   public readonly handler: lambda.Function;
 
-  constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
+  constructor(scope: Construct, id: string, props: HitCounterProps) {
     super(scope, id);
 
     const table = new dynamodb.Table(this, 'Hits', {
@@ -114,22 +115,23 @@ But, we must also give our hit counter permissions to invoke the downstream lamb
 
 Add the highlighted lines to `lib/hitcounter.ts`:
 
-{{<highlight ts "hl_lines=35-36">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as dynamodb from '@aws-cdk/aws-dynamodb';
+{{<highlight ts "hl_lines=36-37">}}
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
   downstream: lambda.IFunction;
 }
 
-export class HitCounter extends cdk.Construct {
+export class HitCounter extends Construct {
 
   /** allows accessing the counter function */
   public readonly handler: lambda.Function;
 
-  constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
+  constructor(scope: Construct, id: string, props: HitCounterProps) {
     super(scope, id);
 
     const table = new dynamodb.Table(this, 'Hits', {

--- a/workshop/content/20-typescript/50-table-viewer/200-install.md
+++ b/workshop/content/20-typescript/50-table-viewer/200-install.md
@@ -9,7 +9,7 @@ Before you can use the table viewer in your application, you'll need to install
 the npm module:
 
 ```
-npm install cdk-dynamo-table-viewer@3.1.2
+npm install cdk-dynamo-table-viewer@0.2.0
 ```
 
 {{% notice info %}}
@@ -24,7 +24,7 @@ in use.
 Output should look like this:
 
 ```
-+ cdk-dynamo-table-viewer@3.1.2
++ cdk-dynamo-table-viewer@0.2.0
 added 1 package from 1 contributor and audited 886517 packages in 6.704s
 found 0 vulnerabilities
 ```

--- a/workshop/content/20-typescript/50-table-viewer/300-add.md
+++ b/workshop/content/20-typescript/50-table-viewer/300-add.md
@@ -10,9 +10,9 @@ Add the following hightlighted lines to
 construct to your stack:
 
 {{<highlight ts "hl_lines=5 26-29">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as apigw from '@aws-cdk/aws-apigateway';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 

--- a/workshop/content/20-typescript/50-table-viewer/400-expose-table.md
+++ b/workshop/content/20-typescript/50-table-viewer/400-expose-table.md
@@ -7,24 +7,25 @@ weight = 400
 
 Edit `hitcounter.ts` and modify it as such `table` is exposed as a public property.
 
-{{<highlight ts "hl_lines=14-15 26">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as dynamodb from '@aws-cdk/aws-dynamodb';
+{{<highlight ts "hl_lines=15-16 27">}}
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
 
 export interface HitCounterProps {
   /** the function for which we want to count url hits **/
   downstream: lambda.IFunction;
 }
 
-export class HitCounter extends cdk.Construct {
+export class HitCounter extends Construct {
   /** allows accessing the counter function */
   public readonly handler: lambda.Function;
 
   /** the hit counter table */
   public readonly table: dynamodb.Table;
 
-  constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
+  constructor(scope: Construct, id: string, props: HitCounterProps) {
     super(scope, id);
 
     const table = new dynamodb.Table(this, "Hits", {
@@ -59,9 +60,9 @@ export class HitCounter extends cdk.Construct {
 Go back to `cdk-workshop-stack.ts` and assign the `table` property of the table viewer:
 
 {{<highlight ts "hl_lines=28">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as apigw from '@aws-cdk/aws-apigateway';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 

--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -19,9 +19,9 @@ same level as `bin` and `lib` and then create a file called `hitcounter.test.ts`
 
 
 ```typescript
-import { Template, Capture } from '@aws-cdk/assertions';
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
+import { Template, Capture } from 'aws-cdk-lib/assertions';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { HitCounter }  from '../lib/hitcounter';
 
 test('DynamoDB Table Created', () => {
@@ -248,9 +248,9 @@ requirement that our DynamoDB table be encrypted.
 First we'll update the test to reflect this new requirement.
 
 {{<highlight ts "hl_lines=6-23">}}
-import { Template, Capture } from '@aws-cdk/assertions';
-import cdk = require('@aws-cdk/core');
-import * as lambda from '@aws-cdk/aws-lambda';
+import { Template, Capture } from 'aws-cdk-lib/assertions';
+import cdk = require('aws-cdk-lib');
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { HitCounter }  from '../lib/hitcounter';
 
 test('DynamoDB Table Created With Encryption', () => {
@@ -324,7 +324,7 @@ $ npm run test
       67 |       SSEEnabled: true
       68 |     }
 
-      at Template.hasResourceProperties (node_modules/@aws-cdk/assertions/lib/template.ts:50:13)
+      at Template.hasResourceProperties (node_modules/aws-cdk-lib/assertions/lib/template.ts:50:13)
       at Object.<anonymous> (test/hitcounter.test.ts:65:12)
 
 Test Suites: 1 failed, 1 total
@@ -337,14 +337,14 @@ Ran all test suites.
 Now lets fix the broken test. Update the hitcounter code to enable encryption by default.
 
 {{<highlight ts "hl_lines=13">}}
-export class HitCounter extends cdk.Construct {
+export class HitCounter extends Construct {
   /** allows accessing the counter function */
   public readonly handler: lambda.Function;
 
   /** the hit counter table */
   public readonly table: dynamodb.Table;
 
-  constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
+  constructor(scope: Construct, id: string, props: HitCounterProps) {
     super(scope, id);
 
     const table = new dynamodb.Table(this, 'Hits', {

--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/2000-validation-tests.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/2000-validation-tests.md
@@ -43,14 +43,14 @@ const table = new dynamodb.Table(this, 'Hits', {
 Now add a validation which will throw an error if the readCapacity is not in the allowed range.
 
 {{<highlight ts "hl_lines=9-11">}}
-export class HitCounter extends cdk.Construct {
+export class HitCounter extends Construct {
   /** allows accessing the counter function */
   public readonly handler: lambda.Function;
 
   /** the hit counter table */
   public readonly table: dynamodb.Table;
 
-  constructor(scope: cdk.Construct, id: string, props: HitCounterProps) {
+  constructor(scope: Construct, id: string, props: HitCounterProps) {
     if (props.readCapacity !== undefined && (props.readCapacity < 5 || props.readCapacity > 20)) {
       throw new Error('readCapacity must be greater than 5 and less than 20');
     }

--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/_index.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/_index.md
@@ -11,7 +11,7 @@ and [Validation](https://docs.aws.amazon.com/cdk/latest/guide/testing.html#testi
 
 #### CDK assert Library
 
-We will be using the CDK `assertions` (`@aws-cdk/assertions`) library throughout this section.
+We will be using the CDK `assertions` (`aws-cdk-lib/assertions`) library throughout this section.
 The library contains several helper functions for writing unit and integration tests.
 
 

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/1000-setting-up.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/1000-setting-up.md
@@ -12,10 +12,11 @@ Since this is separate from our actual "production" application, we want this to
 Create a new file under `lib` called `lib/pipeline-stack.ts`. Add the following to that file.
 
 {{<highlight ts>}}
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export class WorkshopPipelineStack extends cdk.Stack {
-    constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props);
 
         // Pipeline code goes here
@@ -31,35 +32,13 @@ Next, since the purpose of our pipeline is to deploy our application stack, we n
 To do this, edit the code in `bin/cdk-workshop.ts` as follows:
 
 {{<highlight ts "hl_lines=2 5">}}
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { WorkshopPipelineStack } from '../lib/pipeline-stack';
 
 const app = new cdk.App();
 new WorkshopPipelineStack(app, 'CdkWorkshopPipelineStack');
 {{</highlight>}}
 
-## Enable "New-Style" Synthesis
-The construct `@aws-cdk/pipelines` uses new core CDK framework features called "new style stack synthesis". In order to deploy our pipeline, we must enable this feature in our CDK configuration.
-
-Edit the file `cdk.json` as follows:
-
-{{<highlight json "hl_lines=3-5">}}
-{
-    "app": "node bin/cdk-workshop.js",
-    "context": {
-        "@aws-cdk/core:newStyleStackSynthesis": true
-    }
-}
-{{</highlight>}}
-
-This instructs the CDK to use those new features any time it synthesizes a stack (`cdk synth`).
-
-## Special Bootstrap
-There's one last step before we're ready. To have the necessary permissions in your account to deploy the pipeline, we must re-run `cdk bootstrap` with the addition of parameter `--cloudformation-execution-policies`. This will explicitly give the CDK full control over your account and switch over to the new bootstrapping resources enabled in the previous step.
-
-```
-npx cdk bootstrap --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess
-```
 
 And now we're ready!
 

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/2000-create-repo.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/2000-create-repo.md
@@ -8,12 +8,13 @@ The first step in any good CD pipeline is source control. Here we will create a 
 
 Edit the file `lib/pipeline-stack.ts` as follows.
 
-{{<highlight ts "hl_lines=2 8-11">}}
-import * as cdk from '@aws-cdk/core';
-import * as codecommit from '@aws-cdk/aws-codecommit';
+{{<highlight ts "hl_lines=2 9-12">}}
+import * as cdk from 'aws-cdk-lib';
+import * as codecommit from 'aws-cdk-lib/aws-codecommit';
+import { Construct } from 'constructs';
 
 export class WorkshopPipelineStack extends cdk.Stack {
-    constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props);
 
         // Creates a CodeCommit repository called 'WorkshopRepo'
@@ -27,10 +28,8 @@ export class WorkshopPipelineStack extends cdk.Stack {
 {{</highlight>}}
 
 ## Deploy
-Now we can install the missing package and deploy the app to see our new repo.
 
 ```
-npm install @aws-cdk/aws-codecommit
 npx cdk deploy
 ```
 

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/3000-new-pipeline.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/3000-new-pipeline.md
@@ -6,17 +6,18 @@ weight = 130
 ## Define an Empty Pipeline
 Now we are ready to define the basics of the pipeline.
 
-We will be using a new package here, so first `npm install @aws-cdk/pipelines`.
+We will be using a new package here, so first `npm install aws-cdk-lib/pipelines`.
 
 Return to the file `lib/pipeline-stack.ts` and edit as follows:
 
-{{<highlight ts "hl_lines=3 14-30">}}
-import * as cdk from '@aws-cdk/core';
-import * as codecommit from '@aws-cdk/aws-codecommit';
-import {CodeBuildStep, CodePipeline, CodePipelineSource} from "@aws-cdk/pipelines";
+{{<highlight ts "hl_lines=4 15-31">}}
+import * as cdk from 'aws-cdk-lib';
+import * as codecommit from 'aws-cdk-lib/aws-codecommit';
+import { Construct } from 'constructs';
+import {CodeBuildStep, CodePipeline, CodePipelineSource} from "aws-cdk-lib/pipelines";
 
 export class WorkshopPipelineStack extends cdk.Stack {
-    constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props);
 
         // This creates a new CodeCommit repository called 'WorkshopRepo'

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/4000-build-stage.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/4000-build-stage.md
@@ -10,7 +10,8 @@ Create a new file in `lib` called `pipeline-stage.ts` with the code below:
 
 {{<highlight ts>}}
 import { CdkWorkshopStack } from './cdk-workshop-stack';
-import { Stage, Construct, StageProps } from '@aws-cdk/core';
+import { Stage, StageProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export class WorkshopPipelineStage extends Stage {
     constructor(scope: Construct, id: string, props?: StageProps) {
@@ -26,33 +27,35 @@ All this does is declare a new `Stage` (component of a pipeline), and in that st
 Now, at this point your code editor may be telling you that you are doing something wrong. This is because the application stack as it stands now is not configured to be deployed by a pipeline.
 Open `lib/cdk-workshop-stack.ts` and make the following changes:
 
-{{<highlight ts "hl_lines=8">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as apigw from '@aws-cdk/aws-apigateway';
+{{<highlight ts "hl_lines=9">}}
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
+import { Construct } from 'constructs';
 import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 
 export class CdkWorkshopStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     // The rest of your code...
 {{</highlight>}}
 
-This stack's `scope` parameter was defined as being a `cdk.App`, which means that in the construct tree, it must be a child of the app. Since the stack is being deployed by the pipeline, it is no longer a child of the app, so its type must be changed to `cdk.Construct`.
+This stack's `scope` parameter was defined as being a `cdk.App`, which means that in the construct tree, it must be a child of the app. Since the stack is being deployed by the pipeline, it is no longer a child of the app, so its type must be changed to `Construct`.
 
 ## Add stage to pipeline
 Now we must add the stage to the pipeline by adding the following code to `lib/pipeline-stack.ts`:
 
-{{<highlight ts "hl_lines=3 17 33-34">}}
-import * as cdk from '@aws-cdk/core';
-import * as codecommit from '@aws-cdk/aws-codecommit';
+{{<highlight ts "hl_lines=4 18 34-35">}}
+import * as cdk from 'aws-cdk-lib';
+import * as codecommit from 'aws-cdk-lib/aws-codecommit';
+import { Construct } from 'constructs';
 import {WorkshopPipelineStage} from './pipeline-stage';
-import {CodeBuildStep, CodePipeline, CodePipelineSource} from "@aws-cdk/pipelines";
+import {CodeBuildStep, CodePipeline, CodePipelineSource} from "aws-cdk-lib/pipelines";
 
 export class WorkshopPipelineStack extends cdk.Stack {
-    constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props);
 
         // This creates a new CodeCommit repository called 'WorkshopRepo'
@@ -110,15 +113,16 @@ It looks like the build step is failing to find our Lambda function.
 We are currently locating our Lambda code based on the directory that `cdk synth` is being executed in. Since CodeBuild uses a different folder structure than you might for development, it can't find the path to our Lambda code. We can fix that with a small change in `lib/cdk-workshop-stack.ts`:
 
 {{<highlight ts "hl_lines=6 14">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as apigw from '@aws-cdk/aws-apigateway';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
+import { Construct } from 'constructs';
 import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 import * as path from 'path';
 
 export class CdkWorkshopStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {

--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.md
@@ -9,9 +9,10 @@ Stepping back, we can see a problem now that our app is being deployed by our pi
 First edit `lib/cdk-workshop-stack.ts` to get these values and expose them as properties of our stack:
 
 {{<highlight ts "hl_lines=9-10 26 30 36-42">}}
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as apigw from '@aws-cdk/aws-apigateway';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
+import { Construct } from 'constructs';
 import { HitCounter } from './hitcounter';
 import { TableViewer } from 'cdk-dynamo-table-viewer';
 
@@ -19,7 +20,7 @@ export class CdkWorkshopStack extends cdk.Stack {
   public readonly hcViewerUrl: cdk.CfnOutput;
   public readonly hcEndpoint: cdk.CfnOutput;
 
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
@@ -72,14 +73,15 @@ Now we have our application deployed, but no CD pipeline is complete without tes
 Let's start with a simple test to ping our endpoints to see if they are alive.
 Return to `lib/pipeline-stack.ts` and add the following:
 
-{{<highlight ts "hl_lines=15-37">}}
-import * as cdk from '@aws-cdk/core';
-import * as codecommit from '@aws-cdk/aws-codecommit';
+{{<highlight ts "hl_lines=16-38">}}
+import * as cdk from 'aws-cdk-lib';
+import * as codecommit from 'aws-cdk-lib/aws-codecommit';
+import { Construct } from 'constructs';
 import {WorkshopPipelineStage} from './pipeline-stage';
-import {CodeBuildStep, CodePipeline, CodePipelineSource} from "@aws-cdk/pipelines";
+import {CodeBuildStep, CodePipeline, CodePipelineSource} from "aws-cdk-lib/pipelines";
 
 export class WorkshopPipelineStack extends cdk.Stack {
-    constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props);
 
         // PIPELINE CODE HERE...
@@ -122,9 +124,10 @@ You may notice that we have not yet set the URLs of these endpoints. This is bec
 
 With a slight modification to `lib/pipeline-stage.ts` we can expose them:
 
-{{<highlight ts "hl_lines=2 5-6 11 13-14">}}
+{{<highlight ts "hl_lines=2 6-7 12 14-15">}}
 import { CdkWorkshopStack } from './cdk-workshop-stack';
-import { Stage, CfnOutput, Construct, StageProps } from '@aws-cdk/core';
+import { Stage, CfnOutput, StageProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export class WorkshopPipelineStage extends Stage {
     public readonly hcViewerUrl: CfnOutput;
@@ -142,7 +145,7 @@ export class WorkshopPipelineStage extends Stage {
 {{</highlight>}}
 
 Now we can add those values to our actions in `lib/pipeline-stack.ts` by getting the `stackOutput` of our pipeline stack:
-{{<highlight ts "hl_lines=6 16">}}
+{{<highlight ts "hl_lines=6 17">}}
     // CODE HERE...
     deployStage.addPost(
             new CodeBuildStep('TestViewerEndpoint', {


### PR DESCRIPTION
This updates both the workshop content and code for typescript to cdk v2

re #308

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
