### PR TITLE
fix: make syntactical corrections in python/advanced topics module.

### DIFF
--- a/workshop/content/30-python/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/30-python/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -41,7 +41,7 @@ def test_dynamodb_table_created():
     stack = Stack()
     HitCounter(stack, "HitCounter",
             downstream=_lambda.Function(stack, "TestFunction",
-                runtime=_lambda.Runtime.NODEJS_14_X,
+                runtime=_lambda.Runtime.PYTHON_3_7,
                 handler='hello.handler',
                 code=_lambda.Code.from_asset('lambda')),
     )
@@ -104,7 +104,7 @@ def test_lambda_has_env_vars():
     stack = Stack()
     HitCounter(stack, "HitCounter",
             downstream=_lambda.Function(stack, "TestFunction",
-                runtime=_lambda.Runtime.NODEJS_14_X,
+                runtime=_lambda.Runtime.PYTHON_3_7,
                 handler='hello.handler',
                 code=_lambda.Code.from_asset('lambda')))
 
@@ -166,7 +166,7 @@ def test_lambda_has_env_vars():
     stack = Stack()
     HitCounter(stack, "HitCounter",
             downstream=_lambda.Function(stack, "TestFunction",
-                runtime=_lambda.Runtime.NODEJS_14_X,
+                runtime=_lambda.Runtime.PYTHON_3_7,
                 handler='hello.handler',
                 code=_lambda.Code.from_asset('lambda')))
     template = assertions.Template.from_stack(stack)
@@ -215,7 +215,7 @@ def test_dynamodb_with_encryption():
     stack = Stack()
     HitCounter(stack, "HitCounter",
             downstream=_lambda.Function(stack, "TestFunction",
-                runtime=_lambda.Runtime.NODEJS_14_X,
+                runtime=_lambda.Runtime.PYTHON_3_7,
                 handler='hello.handler',
                 code=_lambda.Code.from_asset('lambda')))
 

--- a/workshop/content/30-python/70-advanced-topics/100-construct-testing/2000-validation-tests.md
+++ b/workshop/content/30-python/70-advanced-topics/100-construct-testing/2000-validation-tests.md
@@ -71,7 +71,7 @@ def test_dynamodb_raises():
     with pytest.raises(Exception):
         HitCounter(stack, "HitCounter",
                 downstream=_lambda.Function(stack, "TestFunction",
-                    runtime=_lambda.Runtime.NODEJS_14_X,
+                    runtime=_lambda.Runtime.PYTHON_3_7,
                     handler='hello.handler',
                     code=_lambda.Code.from_asset('lambda')),
                 read_capacity=1,

--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/1000-setting-up.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/1000-setting-up.md
@@ -16,7 +16,6 @@ from constructs import Construct
 from aws_cdk import (
     Stack
 )
-from pipeline_stage import WorkshopPipelineStage
 
 class WorkshopPipelineStack(Stack):
 

--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/2000-create-repo.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/2000-create-repo.md
@@ -32,7 +32,7 @@ class WorkshopPipelineStack(Stack):
 ## Deploy
 
 ```
-npx cdk deploy
+cdk deploy
 ```
 
 ## Get Repo Info and Commit
@@ -70,6 +70,8 @@ git push --set-upstream origin master
 ```
 
 Here, CodeCommit will request the credentials you generated in the **Git Credentials** section. You will only have to provide them once.
+
+> Note: If the `git push` command hangs indefinitely, you may need to follow [these instructions](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html) to set up your git CLI.
 
 ### See Result
 Now you can return to the CodeCommit console and see that your code is all there!

--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/3000-new-pipeline.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/3000-new-pipeline.md
@@ -16,7 +16,6 @@ from aws_cdk import (
     aws_codecommit as codecommit,
     pipelines as pipelines,
 )
-from cdk_workshop.pipeline_stage import WorkshopPipelineStage
 
 class WorkshopPipelineStack(Stack):
     def __init__(self, scope: Construct, id: str, **kwargs) -> None:
@@ -36,7 +35,7 @@ class WorkshopPipelineStack(Stack):
                 commands=[
                     "npm install -g aws-cdk",  # Installs the cdk cli on Codebuild
                     "pip install -r requirements.txt",  # Instructs Codebuild to install required packages
-                    "npx cdk synth",
+                    "cdk synth",
                 ]
             ),
         )
@@ -54,7 +53,7 @@ All that's left to get our pipeline up and running is to commit our changes and 
 
 ```
 git commit -am "MESSAGE" && git push
-npx cdk deploy
+cdk deploy
 ```
 
 CdkPipelines auto-update for each commit in a source repo, so this is the *last time* we will need to execute this command!

--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/4000-build-stage.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/4000-build-stage.md
@@ -36,7 +36,7 @@ from aws_cdk import (
     aws_codecommit as codecommit,
     pipelines as pipelines,
 )
-from pipeline_stage import WorkshopPipelineStage
+from cdk_workshop.pipeline_stage import WorkshopPipelineStage
 
 class WorkshopPipelineStack(Stack):
     def __init__(self, scope: Construct, id: str, **kwargs) -> None:


### PR DESCRIPTION
This PR contains small syntactical corrections for the Advanced Topics module of the python tutorial. It appears that some of it was copy/pasted from other iterations of the tutorial, and the steps as outlined don't work. This fixes a good portion of them. Below are the original errors that have been corrected:
1. All of the tests use a node JS runtime for the Lambda instead of a Python runtime.
1. Under "Getting started with pipelines/Create Pipeline Stack," the code includes `from pipeline_stage import WorkshopPipelineStage`. This dependency does not exist yet at this part in the tutorial
1. Under "Create repository/Deploy," the source instructs the user to enter `npx cdk deploy`. I think this might be copy/pasted from the TypeScript workshop and should be just `cdk deploy`
1. Under "Create repository/Add Git Remote," when I try to `git push --set-upstream origin master`, it just hangs. I am using Ubuntu on Windows Subsystem for Linux 1. I had to follow https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html to get it to work.
1. Under "Create New Pipeline/Define an Empty Pipeline" there is again reference to a dependency that does not yet exist: `from cdk_workshop.pipeline_stage import WorkshopPipelineStage`
1. Under "Create New Pipeline/Define an Empty Pipeline" it looks like this is also configured for TypeScript (it says `npx cdk synth` where I believe it should just be `cdk synth`). Below, under deploy, it should also just be `cdk deploy`.
1. Under "Add application to pipeline/Add stage to pipeline," it only works for me if I include the full input path of `from cdk_workshop.pipeline_stage import WorkshopPipelineStage`. I thought at first this could be due to my python version (3.8.10), but it also fails the "Build" stage in the CodePipelines console with the same error. Error below:
```
[Container] 2021/12/03 16:08:57 Running command cdk synth
--
Traceback (most recent call last):
File "/codebuild/output/src789020068/src/app.py", line 4, in <module>
from cdk_workshop.pipeline_stack import WorkshopPipelineStack
File "/codebuild/output/src789020068/src/cdk_workshop/pipeline_stack.py", line 7, in <module>
from pipeline_stage import WorkshopPipelineStage
ModuleNotFoundError: No module named 'pipeline_stage'
Subprocess exited with error 1
```

For the final, more complicated issue I ran into, I opened the following issue: https://github.com/aws-samples/aws-cdk-intro-workshop/issues/362

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
