### PR TITLE
fix: include TableViewer dependency in Python requirements.txt

### DIFF
--- a/workshop/content/30-python/50-table-viewer/200-install.md
+++ b/workshop/content/30-python/50-table-viewer/200-install.md
@@ -6,13 +6,15 @@ weight = 200
 ## pip install
 
 Before you can use the table viewer in your application, you'll need to install
-the python module:
+the python module. To do this, make the following updates to `requirements.txt`:
 
-```
-pip install cdk-dynamo-table-view==0.2.0
-```
+{{<highlight python "hl_lines=13 3">}}
+aws-cdk-lib==2.0.0
+constructs>=10.0.0,<11.0.0
+cdk-dynamo-table-view==0.2.0
+{{</highlight>}}
 
-The last two lines of the output (there's a lot of it) should look like this:
+and again run `pip install -r requirements.txt`. The last two lines of the output (there's a lot of it) should look like this:
 
 ```
 Installing collected packages: cdk-dynamo-table-view


### PR DESCRIPTION
In the Python tutorial, when making use of the external TableViewer construct, the dependency is never added to the `requirements.txt` file. This leads to later failures in the tutorial as the pipeline fails to include the dependency, as referenced in https://github.com/aws-samples/aws-cdk-intro-workshop/issues/362. This update instructs the user to add it to their `requirements.txt` file so that later steps will work correctly.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
