### PR TITLE
fix: correcting modules name

### DIFF
--- a/workshop/content/30-python/50-table-viewer/300-add.md
+++ b/workshop/content/30-python/50-table-viewer/300-add.md
@@ -17,7 +17,7 @@ from aws_cdk import (
     aws_apigateway as apigw,
 )
 
-from cdk_dynamo_table_viewer import TableViewer
+from cdk_dynamo_table_view import TableViewer
 from .hitcounter import HitCounter
 
 class CdkWorkshopStack(Stack):


### PR DESCRIPTION
using table_viewer throws an error
```
(venv) cdk_workshop ❯ cdk diff                                                                                                                                                                master
Traceback (most recent call last):
  File "/Users/jwelling/code/cdk_workshop/app.py", line 5, in <module>
    from cdk_workshop.cdk_workshop_stack import CdkWorkshopStack
  File "/Users/jwelling/code/cdk_workshop/cdk_workshop/cdk_workshop_stack.py", line 7, in <module>
    from cdk_dynamo_table_viewer import TableViewer
ModuleNotFoundError: No module named 'cdk_dynamo_table_viewer'
```

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
