### PR TITLE
fix: Removing 'from pipeline_stage import WorkshopPipelineStage' in pipe…

### DIFF
--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/1000-setting-up.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/1000-setting-up.md
@@ -16,7 +16,6 @@ from constructs import Construct
 from aws_cdk import (
     Stack
 )
-from pipeline_stage import WorkshopPipelineStage
 
 class WorkshopPipelineStack(Stack):
 


### PR DESCRIPTION
…line setting up

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

As per https://cdkworkshop.com/30-python/70-advanced-topics/200-pipelines/1000-setting-up.html, keeping below line of code inside 'pipeline_stack.py' fails while doing 'cdk synth' and also 'npx cdk deploy' in then next 2000-create-repo.html page.

# from pipeline_stage import WorkshopPipelineStage


Fixes # <!-- Please create a new issue if none exists yet -->

Removing this line from above python code succeeds 'cdk synth' and 'npx cdk deploy'
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
