### PR TITLE
fix(python docs): updated `cdk_dynamo_table_viewer` -> `cdk_dynamo_table_view`

### DIFF
--- a/workshop/content/30-python/50-table-viewer/300-add.md
+++ b/workshop/content/30-python/50-table-viewer/300-add.md
@@ -5,7 +5,7 @@ weight = 300
 
 ## Add a table viewer to your stack
 
-Add the following hightlighted lines to
+Add the following highlighted lines to
 `cdk_workshop_stack.py` to add a `TableViewer`
 construct to your stack:
 
@@ -17,7 +17,7 @@ from aws_cdk import (
     aws_apigateway as apigw,
 )
 
-from cdk_dynamo_table_viewer import TableViewer
+from cdk_dynamo_table_view import TableViewer
 from .hitcounter import HitCounter
 
 class CdkWorkshopStack(Stack):

--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/5000-test-actions.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/5000-test-actions.md
@@ -16,7 +16,7 @@ from aws_cdk import (
     aws_lambda as _lambda,
     aws_apigateway as apigw,
 )
-from cdk_dynamo_table_viewer import TableViewer
+from cdk_dynamo_table_view import TableViewer
 from .hitcounter import HitCounter
 
 class CdkWorkshopStack(Stack):


### PR DESCRIPTION
## Summary

This PR updates uses of the python module `cdk_dynamo_table_viewer` with the correct name `cdk_dynamo_table_view`

ref: https://pypi.org/project/cdk-dynamo-table-view/

Fixes #414 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
