### PR TITLE
Add notice to compile TypeScript before running test

### DIFF
--- a/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -356,6 +356,8 @@ export class HitCounter extends Construct {
 }
 {{</highlight>}}
 
+{{% notice info %}} You must compile your updated TypeScript to JavaScript for the test to pick up your changes successfully. If you do not have "npm run watch" still running in a terminal, run this command again to compile the TypeScript. {{% /notice %}}
+
 Now run the test again, which should now pass.
 
 ```bash


### PR DESCRIPTION
Add a notice that the updated TypeScript must be compiled again before running the test that validates the change. If the developer has stopped running `npm run watch` when going through this part of the tutorial, they may not know that the TypeScript needs to be recompiled first before the test will pick up the changes made.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
