### PR TITLE
Update 3000-new-pipeline.md

### DIFF
--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/3000-new-pipeline.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/3000-new-pipeline.md
@@ -6,7 +6,7 @@ weight = 130
 ## Define an Empty Pipeline
 Now we are ready to define the basics of the pipeline.
 
-We will be using a new package here, so first `npm install aws-cdk-lib/pipelines`.
+We will be using a new package here, so first `npm install @aws-cdk/pipelines`.
 
 Return to the file `lib/pipeline-stack.ts` and edit as follows:
 


### PR DESCRIPTION
When running through the workshop last night I found that `npm install aws-cdk-lib/pipelines` did not work and that I had to modify this to be  `npm install @aws-cdk/pipelines`

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
