### PR TITLE
fix: workshop says to install package present in aws-cdk-lib

### DIFF
--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/3000-new-pipeline.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/3000-new-pipeline.md
@@ -6,8 +6,6 @@ weight = 130
 ## Define an Empty Pipeline
 Now we are ready to define the basics of the pipeline.
 
-We will be using a new package here, so first `npm install aws-cdk-lib/pipelines`.
-
 Return to the file `lib/pipeline-stack.ts` and edit as follows:
 
 {{<highlight ts "hl_lines=4 15-31">}}


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes #541 <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
