### PR TITLE
Update footer with the copyright year range

### DIFF
--- a/workshop/layouts/partials/menu-footer.html
+++ b/workshop/layouts/partials/menu-footer.html
@@ -1,5 +1,5 @@
 <left>
 
-    <a href="https://aws.amazon.com/privacy/?nc1=f_pr">Privacy</a> | <a href="https://aws.amazon.com/terms/?nc1=f_pr">Site Terms</a> | © 2020, Amazon Web Services, Inc. or its affiliates. All rights reserved. 
+    <a href="https://aws.amazon.com/privacy/?nc1=f_pr">Privacy</a> | <a href="https://aws.amazon.com/terms/?nc1=f_pr">Site Terms</a> | © 2020-2022, Amazon Web Services, Inc. or its affiliates. All rights reserved. 
 
 </left>


### PR DESCRIPTION
The footer currently says `(c) 2020` only - updated it to say `(c) 2020-2022`

****

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).