### PR TITLE
Python fix handler reference

### DIFF
--- a/code/python/main-workshop/cdk_workshop/hitcounter.py
+++ b/code/python/main-workshop/cdk_workshop/hitcounter.py
@@ -34,5 +34,5 @@ class HitCounter(Construct):
             },
         )
 
-        self._table.grant_read_write_data(self.handler)
-        downstream.grant_invoke(self.handler)
+        self._table.grant_read_write_data(self._handler)
+        downstream.grant_invoke(self._handler)

--- a/workshop/content/30-python/40-hit-counter/600-permissions.md
+++ b/workshop/content/30-python/40-hit-counter/600-permissions.md
@@ -41,7 +41,7 @@ class HitCounter(Construct):
             }
         )
 
-        table.grant_read_write_data(self.handler)
+        table.grant_read_write_data(self._handler)
 {{</highlight>}}
 
 ## Deploy
@@ -143,8 +143,8 @@ class HitCounter(Construct):
             }
         )
 
-        table.grant_read_write_data(self.handler)
-        downstream.grant_invoke(self.handler)
+        table.grant_read_write_data(self._handler)
+        downstream.grant_invoke(self._handler)
 {{</highlight>}}
 
 ## Diff


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->
Corrected Lambda function handler reference in hitcounter.py.

Forked https://github.com/dennydaugherty/aws-cdk-intro-workshop/pull/1 and updated base repository. 
Fixes https://github.com/aws-samples/aws-cdk-intro-workshop/issues/463

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
