### PR TITLE
Fix highlighting in 'Polish Pipeline' step of TS and .NET workshops

### DIFF
--- a/workshop/content/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.md
+++ b/workshop/content/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.md
@@ -145,7 +145,7 @@ export class WorkshopPipelineStage extends Stage {
 {{</highlight>}}
 
 Now we can add those values to our actions in `lib/pipeline-stack.ts` by getting the `stackOutput` of our pipeline stack:
-{{<highlight ts "hl_lines=6 17">}}
+{{<highlight ts "hl_lines=6 15">}}
     // CODE HERE...
     deployStage.addPost(
             new CodeBuildStep('TestViewerEndpoint', {

--- a/workshop/content/40-dotnet/70-advanced-topics/100-pipelines/5000-test-actions.md
+++ b/workshop/content/40-dotnet/70-advanced-topics/100-pipelines/5000-test-actions.md
@@ -153,7 +153,7 @@ namespace CdkWorkshop
 {{</highlight>}}
 
 Now we can add those values to our actions in `CdkWorkshop/PipelineStack.cs` by getting the `CfnOutput` of our deploy stage:
-{{<highlight ts "hl_lines=6 15">}}
+{{<highlight ts "hl_lines=5 11">}}
 // CODE HERE...
 
 deployStage.AddPost(new ShellStep("TestViewerEndpoint", new ShellStepProps{


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes #585 <!-- Please create a new issue if none exists yet -->
Fixes highlighting of ENDPOINT_URL in Typescript and .NET workshops
* https://cdkworkshop.com/20-typescript/70-advanced-topics/200-pipelines/5000-test-actions.html
* https://cdkworkshop.com/40-dotnet/70-advanced-topics/100-pipelines/5000-test-actions.html
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
