### PR TITLE
fix: license fixup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,6 @@ Fixes # <!-- Please create a new issue if none exists yet -->
 
 ---
 
-By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].
+By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].
 
-[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
+[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+MIT No Attribution
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software


### PR DESCRIPTION
The license for this repository is MIT-0, but the pull request template says Apache 2.0. This corrects the discrepancy.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
