### PR TITLE
Fix link to AWS CLI configuration

### DIFF
--- a/workshop/content/20-typescript/20-create-project/500-deploy.md
+++ b/workshop/content/20-typescript/20-create-project/500-deploy.md
@@ -28,7 +28,7 @@ Then:
 
 {{% notice info %}}
 If you are returned an Access Denied message at this step, verify that
-you have [configured the AWS CLI correctly]((/15-prerequisites/200-account.html)) (or, specified an appropriate secret/access key), and also verify that you have permission to call `cloudformation:CreateChangeSet` within the scope of your [account/session](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
+you have [configured the AWS CLI correctly](/15-prerequisites/200-account.html) (or, specified an appropriate secret/access key), and also verify that you have permission to call `cloudformation:CreateChangeSet` within the scope of your [account/session](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
 {{% /notice %}}
 
 ## Let's deploy

--- a/workshop/content/30-python/20-create-project/500-deploy.md
+++ b/workshop/content/30-python/20-create-project/500-deploy.md
@@ -28,7 +28,7 @@ Then:
 
 {{% notice info %}}
 If you are returned an Access Denied message at this step, verify that
-you have [configured the AWS CLI correctly]((/15-prerequisites/200-account.html)) (or, specified an appropriate secret/access key), and also verify that you have permission to call `cloudformation:CreateChangeSet` within the scope of your [account/session](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
+you have [configured the AWS CLI correctly](/15-prerequisites/200-account.html) (or, specified an appropriate secret/access key), and also verify that you have permission to call `cloudformation:CreateChangeSet` within the scope of your [account/session](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
 {{% /notice %}}
 ## Let's deploy
 

--- a/workshop/content/40-dotnet/20-create-project/500-deploy.md
+++ b/workshop/content/40-dotnet/20-create-project/500-deploy.md
@@ -28,7 +28,7 @@ Then:
 
 {{% notice info %}}
 If you are returned an Access Denied message at this step, verify that
-you have [configured the AWS CLI correctly]((/15-prerequisites/200-account.html)) (or, specified an appropriate secret/access key), and also verify that you have permission to call `cloudformation:CreateChangeSet` within the scope of your [account/session](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
+you have [configured the AWS CLI correctly](/15-prerequisites/200-account.html) (or, specified an appropriate secret/access key), and also verify that you have permission to call `cloudformation:CreateChangeSet` within the scope of your [account/session](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
 {{% /notice %}}
 
 ## Let's deploy

--- a/workshop/content/50-java/20-create-project/500-deploy.md
+++ b/workshop/content/50-java/20-create-project/500-deploy.md
@@ -28,7 +28,7 @@ Then:
 
 {{% notice info %}}
 If you are returned an Access Denied message at this step, verify that
-you have [configured the AWS CLI correctly]((/15-prerequisites/200-account.html)) (or, specified an appropriate secret/access key), and also verify that you have permission to call `cloudformation:CreateChangeSet` within the scope of your [account/session](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
+you have [configured the AWS CLI correctly](/15-prerequisites/200-account.html) (or, specified an appropriate secret/access key), and also verify that you have permission to call `cloudformation:CreateChangeSet` within the scope of your [account/session](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
 {{% /notice %}}
 
 ## Let's deploy

--- a/workshop/content/60-go/20-create-project/500-deploy.md
+++ b/workshop/content/60-go/20-create-project/500-deploy.md
@@ -28,7 +28,7 @@ Then:
 
 {{% notice info %}}
 If you are returned an Access Denied message at this step, verify that
-you have [configured the AWS CLI correctly]((/15-prerequisites/200-account.html)) (or, specified an appropriate secret/access key), and also verify that you have permission to call `cloudformation:CreateChangeSet` within the scope of your [account/session](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
+you have [configured the AWS CLI correctly](/15-prerequisites/200-account.html) (or, specified an appropriate secret/access key), and also verify that you have permission to call `cloudformation:CreateChangeSet` within the scope of your [account/session](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
 {{% /notice %}}
 
 ## Let's deploy


### PR DESCRIPTION
Hi team,

These links are broken

![image](https://user-images.githubusercontent.com/1225343/189334373-eddb9785-1281-47d1-ad51-5b787ebd42fa.png)

they go to 

![image](https://user-images.githubusercontent.com/1225343/189334437-a011f520-aec0-4e59-9470-5f8afec6157c.png)
