### PR TITLE
Update Testing our function documentation

### DIFF
--- a/workshop/content/30-python/30-hello-cdk/200-lambda.md
+++ b/workshop/content/30-python/30-hello-cdk/200-lambda.md
@@ -198,11 +198,11 @@ Let's go to the AWS Lambda Console and test our function.
 
     ![](./lambda-2.png)
 
-4. Select __Amazon API Gateway AWS Proxy__ from the __Event template__ list.
-
-5. Enter `test` under __Event name__.
+4. Enter `test` under __Event name__.
 
     ![](./lambda-3.png)
+
+5. Select __Amazon API Gateway AWS Proxy__ from the __Event template__ list.
 
 6. Hit __Create__.
 


### PR DESCRIPTION
Move entering name of test before selecting `Amazon API Gateway AWS Proxy` template as entering name of test comes first when creating a test.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
