### PR TITLE
Added instructions to install AWS-SDK for Counter.

### DIFF
--- a/workshop/content/english/20-typescript/40-hit-counter/200-handler.md
+++ b/workshop/content/english/20-typescript/40-hit-counter/200-handler.md
@@ -5,6 +5,8 @@ weight = 100
 
 ## Hit counter Lambda handler
 
+First, we need to install the AWS SDK. While in the root directory of the project, run `npm i aws-sdk`.
+
 Okay, now let's write the Lambda handler code for our hit counter.
 
 Create the file `lambda/hitcounter.js`:


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes #730

This PR adds a line to the instructions in the Hit Counter phase of the TypeScript instructions that tells the user that they need to install the AWS SDK because it hasn't previously been mentioned to the user.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
