### PR TITLE
Update 1000-assertion-test.md

### DIFF
--- a/workshop/content/english/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
+++ b/workshop/content/english/20-typescript/70-advanced-topics/100-construct-testing/1000-assertion-test.md
@@ -12,8 +12,7 @@ weight = 200
 Our `HitCounter` construct creates a simple DynamoDB table. Lets create a test that
 validates that the table is getting created.
 
-If `cdk init` created a test directory for you, then you should have a `cdk-workshop.test.ts` file. Delete this file.
-
+If `cdk init` created a test directory for you, then you should have a `cdk-workshop.test.ts` file.
 If you do not already have a `test` directory (usually created automatically when you run `cdk init`), then create a `test` directory at the
 same level as `bin` and `lib` and then create a file called `hitcounter.test.ts` with the following code.
 


### PR DESCRIPTION
It is unclear, why if the `cdk-workshop.test.ts` was created initially by `cdk init` , you need to delete this file, But it was not, you need to create it.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
