### PR TITLE
📚 docs: typo fixes in the Go workshop

### DIFF
--- a/workshop/content/english/60-go/70-advanced-topics/200-pipelines/1000-setting-up.md
+++ b/workshop/content/english/60-go/70-advanced-topics/200-pipelines/1000-setting-up.md
@@ -68,7 +68,7 @@ package main
 import (
 	"github.com/aws/aws-cdk-go/awscdk/v2"
 	"github.com/aws/jsii-runtime-go"
-)pip
+)
 
 func main() {
 	defer jsii.Close()

--- a/workshop/content/english/60-go/70-advanced-topics/200-pipelines/5000-test-actions.md
+++ b/workshop/content/english/60-go/70-advanced-topics/200-pipelines/5000-test-actions.md
@@ -227,7 +227,7 @@ func (s *workshopPipelineStage) HcEndpoint() awscdk.CfnOutput {
 }
 {{</highlight>}}
 
-Now we can add those values to our actions in `lib/pipeline-stack.ts` by getting the `stackOutput` of our pipeline stack:
+Now we can add those values to our actions in `infra/pipeline-stack.go` by getting the `stackOutput` of our pipeline stack:
 {{<highlight go "hl_lines=2 8 15">}}
 	// CODE HERE...
 	deployStage := pipeline.AddStage(deploy.Stage(), nil)


### PR DESCRIPTION
During the workshop DevFest Strasbourg 2022, last Friday, with François Bouteruche and Olivier Leplus, I found 2 typos in the Go version of the workshop. So I updated the documentation.

Moreover, I performed all steps/chapters of the workshop, with the latest versions available on my MacOS (Catalina 10.15.7)
My versions tested are:
awscli (2.8.13 -> 2.9.0), six v1.16.0
with Go v1.19.3, node v19.1.0, c-ares v1.18.1, libnghttp2 v1.50

Kind regards,
David Aparicio, DataOps @ OVHcloud
