### PR TITLE
Fix Construct Hub link on main page

### DIFF
--- a/workshop/content/english/_index.md
+++ b/workshop/content/english/_index.md
@@ -43,7 +43,7 @@ By the end of this workshop, you'll be able to:
 - Define your own reusable constructs<br/>
 - Consume constructs published by other people<br/>
 
-You can also find a short guide on utilizing our [Construct Hub](./300-nodejs.html) at the end of this workshop. This will be a useful tool for all future endeavors with the CDKs.
+You can also find a short guide on utilizing our [Construct Hub](./70-construct-hub.html) at the end of this workshop. This will be a useful tool for all future endeavors with the CDKs.
 
 ## See Also
 


### PR DESCRIPTION
Hi folks,

This link currently 
<img width="1369" alt="Screenshot 2022-12-05 at 11 58 16" src="https://user-images.githubusercontent.com/1225343/205620998-7e987d4f-766e-47b3-9abc-4dc710f02797.png">

results into 

<img width="1022" alt="Screenshot 2022-12-05 at 11 59 11" src="https://user-images.githubusercontent.com/1225343/205621049-94fccce0-5398-43d9-838b-477271253b82.png">

Please check a fix.
Thanks

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
