### PR TITLE
Removed unnecessary comma

### DIFF
--- a/workshop/content/english/30-python/30-hello-cdk/100-cleanup.md
+++ b/workshop/content/english/30-python/30-hello-cdk/100-cleanup.md
@@ -15,7 +15,7 @@ this:
 ```python
 from constructs import Construct
 from aws_cdk import (
-    Stack,
+    Stack
 )
 
 


### PR DESCRIPTION
Comma after Stack in aws_cdk import caused syntax error. Removed comma.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
