### PR TITLE
Fix typo in 100-api.md[english][python]

### DIFF
--- a/workshop/content/english/30-python/40-hit-counter/100-api.md
+++ b/workshop/content/english/30-python/40-hit-counter/100-api.md
@@ -34,4 +34,4 @@ Save the file.
 
 ----
 
-Next, are are going to write the handler code of our hit counter.
+Next, we are going to write the handler code of our hit counter.


### PR DESCRIPTION
&nbsp;
Fixed small typo in [100-api.md](https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/workshop/content/english/30-python/40-hit-counter/100-api.md) file.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
