### PR TITLE
Use NODEJS_16_X instead of NODEJS_14_X

### DIFF
--- a/workshop/content/english/20-typescript/30-hello-cdk/200-lambda.md
+++ b/workshop/content/english/20-typescript/30-hello-cdk/200-lambda.md
@@ -74,7 +74,7 @@ export class CdkWorkshopStack extends cdk.Stack {
 
     // defines an AWS Lambda resource
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_14_X,    // execution environment
+      runtime: lambda.Runtime.NODEJS_16_X,    // execution environment
       code: lambda.Code.fromAsset('lambda'),  // code loaded from "lambda" directory
       handler: 'hello.handler'                // file is "hello", function is "handler"
     });
@@ -84,7 +84,7 @@ export class CdkWorkshopStack extends cdk.Stack {
 
 A few things to notice:
 
-- Our function uses the NodeJS (`NODEJS_14_X`) runtime
+- Our function uses the NodeJS (`NODEJS_16_X`) runtime
 - The handler code is loaded from the `lambda` directory which we created
   earlier. Path is relative to where you execute `cdk` from, which is the
   project's root directory


### PR DESCRIPTION
Since NODEJS_14_X will be deprecated soon.

This is the warning.
```
Using Node.js version 14 to execute analysis is deprecated and will stop being supported no earlier than May 1st, 2023. Please upgrade to a newer LTS version of Node.js [16, 18]
```

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
