### PR TITLE
ensure npm is up to date to prevent build errors

### DIFF
--- a/workshop/content/english/20-typescript/70-advanced-topics/200-pipelines/3000-new-pipeline.md
+++ b/workshop/content/english/20-typescript/70-advanced-topics/200-pipelines/3000-new-pipeline.md
@@ -30,6 +30,7 @@ export class WorkshopPipelineStack extends cdk.Stack {
             synth: new CodeBuildStep('SynthStep', {
                     input: CodePipelineSource.codeCommit(repo, 'main'),
                     installCommands: [
+                        'npm install -g npm@latest'
                         'npm install -g aws-cdk'
                     ],
                     commands: [


### PR DESCRIPTION
If you follow this workshop as it's currently written, you get an error (npm ERR! Cannot read property 'aws-cdk-lib' of undefined) when running 'npm ci' Updating npm before build removes the error, so proposing that command be added to the install steps

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
