### PR TITLE
Clarify arguments forwarded to base Construct class

### DIFF
--- a/workshop/content/english/20-typescript/40-hit-counter/100-api.md
+++ b/workshop/content/english/20-typescript/40-hit-counter/100-api.md
@@ -31,8 +31,8 @@ Save the file. Oops, an error! No worries, we'll be using `props` shortly.
 ## What's going on here?
 
 * We declared a new construct class called `HitCounter`.
-* As usual, constructor arguments are `scope`, `id` and `props`, and we
-  propagate them to the `cdk.Construct` base class.
+* As usual, constructor arguments are `scope`, `id` and `props`. And as usual, we
+  propagate `scope` and `id` to the `cdk.Construct` base class.
 * The `props` argument is of type `HitCounterProps` which includes a single
   property `downstream` of type `lambda.IFunction`. This is where we are going to "plug in" the
   Lambda function we created in the previous chapter so it can be hit-counted.


### PR DESCRIPTION
The current documentation implies we forward `props` to the `cdk.Construct` base class while the code does not.
This PR is an attempt to make the documentation better represent what the code does.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License](https://github.com/aws/mit-0/blob/master/MIT-0)