### PR TITLE
Fixed typo in _index.md [english][typescript]

### DIFF
--- a/workshop/content/english/20-typescript/70-advanced-topics/200-pipelines/_index.md
+++ b/workshop/content/english/20-typescript/70-advanced-topics/200-pipelines/_index.md
@@ -8,7 +8,7 @@ bookCollapseSection = true
 
 In this chapter we will create a Continuous Deployment (CD) pipeline for the app developed in previous chapters.
 
-CD is an important component to most web project, but can be challenging to set up with all the moving parts required. The [CDK Pipelines](https://docs.aws.amazon.com/cdk/latest/guide/cdk_pipeline.html) construct makes that process easy and streamlined from within your existing CDK infrastructure design.
+CD is an important component in most web projects, but can be challenging to set up with all the moving parts required. The [CDK Pipelines](https://docs.aws.amazon.com/cdk/latest/guide/cdk_pipeline.html) construct makes that process easy and streamlined from within your existing CDK infrastructure design.
 
 These pipelines consist of "stages" that represent the phases of your deployment process from how the source code is managed, to how the fully built artifacts are deployed.
 


### PR DESCRIPTION
Fixed a minor typo in the [_index.md](https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/workshop/content/english/20-typescript/70-advanced-topics/200-pipelines/_index.md) file.

Fixes #901 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
