### PR TITLE
docs: fixed markdown syntax for link

### DIFF
--- a/workshop/content/english/15-prerequisites/900-go.md
+++ b/workshop/content/english/15-prerequisites/900-go.md
@@ -4,6 +4,6 @@ weight = 900
 +++
 
 If you are planning on using the Go Workshop, you will need to
-install Go. You can download Go from (go.dev)[https://go.dev/],
+install Go. You can download Go from [go.dev](https://go.dev/),
 the download page will show the stable versions, all of which
 will work with CDK.

--- a/workshop/content/japanese/15-prerequisites/900-go.md
+++ b/workshop/content/japanese/15-prerequisites/900-go.md
@@ -3,5 +3,5 @@ title = "Go"
 weight = 900
 +++
 
-Go Workshop を始める前に、Go をインストールをする必要があります。Go は、(go.dev)[https://go.dev/] からダウンロードできます。
+Go Workshop を始める前に、Go をインストールをする必要があります。Go は、[go.dev](https://go.dev/) からダウンロードできます。
 ダウンロードページの stable バージョンのどれでも、 CDK は動作します。


### PR DESCRIPTION
Fixes #881 

In the english and japanese workshop the link to the go.dev web page contained a broken Markdown link syntax.
(go.dev)[https://go.dev/] instead of [go.dev](https://go.dev/)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
