### PR TITLE
Updated _index.md

### DIFF
--- a/workshop/content/english/50-java/60-cleanups/_index.md
+++ b/workshop/content/english/50-java/60-cleanups/_index.md
@@ -80,6 +80,12 @@ public class HitCounter extends Construct {
 }
 {{</highlight>}}
 
+Since we made a change in the construct file, we need to redeploy the stack to put the changes into effect. Use `cdk deploy`:
+
+```
+cdk deploy
+```
+
 Additionally, the Lambda function created will generate CloudWatch logs that are
 permanently retained. These will not be tracked by CloudFormation since they are
 not part of the stack, so the logs will still persist. You will have to manually


### PR DESCRIPTION
Since we have made a change in Table removal policy(.removalPolicy(RemovalPolicy.DESTROY)), we need to re-deploy the stack. Otherwise when we execute `cdk destroy` , the DynamoDb table will not be destroyed.




By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
