### PR TITLE
fix "environment" typo

### DIFF
--- a/workshop/content/english/30-python/20-create-project/300-structure.md
+++ b/workshop/content/english/30-python/20-create-project/300-structure.md
@@ -15,7 +15,7 @@ You'll see something like this:
 
 ![](./structure.png)
 
-* .venv - The python virtual envirnment information discussed in the previous section.
+* .venv - The python virtual environment information discussed in the previous section.
 * cdk_workshop — A Python module directory.
   * cdk_workshop.egg-info - Folder that contains build information relevant for the packaging on the project
   * cdk_workshop_stack.py—A custom CDK stack construct for use in your CDK application.


### PR DESCRIPTION
There was a typo in the word "environment" - fixed it
