### PR TITLE
fix: removed unneccessary dropdown

### DIFF
--- a/workshop/content/english/70-construct-hub/_index.md
+++ b/workshop/content/english/70-construct-hub/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Construct Hub"
 weight = 70
-bookCollapseSection = true
+bookCollapseSection = false
 +++
 
 # Construct Hub

--- a/workshop/content/japanese/70-construct-hub/_index.md
+++ b/workshop/content/japanese/70-construct-hub/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Construct Hub"
 weight = 70
-bookCollapseSection = true
+bookCollapseSection = false
 +++
 
 # Construct Hub


### PR DESCRIPTION
The construct hub section consists only of one page and hence does not need a drop down menu.

Fixes #812 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
