### PR TITLE
fixing pulling of dotnet sdk

### DIFF
--- a/workshop/content/english/40-dotnet/70-advanced-topics/100-pipelines/3000-new-pipeline.md
+++ b/workshop/content/english/40-dotnet/70-advanced-topics/100-pipelines/3000-new-pipeline.md
@@ -38,9 +38,18 @@ namespace CdkWorkshop
                 Synth = new ShellStep("Synth", new ShellStepProps{
                     Input = CodePipelineSource.CodeCommit(repo, "main"),  // Where to get source code to build
                     Commands = new string[] {
+             
                         "npm install -g aws-cdk",
-                        "sudo apt-get install -y dotnet-sdk-3.1", // Language-specific install cmd
-                        "dotnet build"  // Language-specific build cmd
+                        "wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb",
+                        "sudo dpkg -i packages-microsoft-prod.deb",
+                        "sudo apt-get update",
+                        "sudo apt-get install -y dotnet-sdk-3.1",
+                        "cd src",
+
+                        "dotnet build", // Language-specific build cmd
+                        "cd ..",
+                        "npx cdk synth"
+
                     }
                 }),
             });


### PR DESCRIPTION
using wget to pull Debian packages from Microsoft for installing dotnet sdk in liunx then running sudo apt-get install to install dotnet sdk. the changes are tested and working repo link is below 
https://github.com/ubaidullah-r/dot-net-aws-cdk

<!--
Explain what changed and why.
in cdk docs below code is intended for installing dotnet sdk 3.1 but it falling to do so
"sudo apt-get install -y dotnet-sdk-3.1"
- i found correct way of doing this by first pulling Debian production packages for ubuntu from official Microsoft website by "wget".
- 
*)The first command downloads a package file called "packages-microsoft-prod.deb" from Microsoft's package repository URL and saves it to the current directory. The "wget" command is used to download files from the internet.
 - "wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-Microsoft-prod.deb",

*)The second command installs the package using the dpkg package manager with root privileges (sudo). This allows the package to be installed system-wide, rather than just for the current user. Once installed, the package repository is configured and ready to use.
 - "sudo dpkg -i packages-Microsoft-prod.deb", 

*)Then we updates the package list on the system, which ensures that the latest package versions are available for installation.
Please read the [Contribution guidelines][1] and follow the pull-request
checklist.
 - "sudo apt-get update"
 
*) And finally installs the .NET Core SDK version 3.1 using the apt package manager with root privileges (sudo).
  - "sudo apt-get install -y dotnet-sdk-3.1",
  - 
[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
