### PR TITLE
Update 2000-create-repo.md

### DIFF
--- a/workshop/content/english/20-typescript/70-advanced-topics/200-pipelines/2000-create-repo.md
+++ b/workshop/content/english/20-typescript/70-advanced-topics/200-pipelines/2000-create-repo.md
@@ -84,7 +84,7 @@ git remote add origin XXXXX
 Now all we need to do is to push our code to the repo (`--set-upstream` tells Git to override the current empty main branch on your repo):
 
 ```
-git push --set-upstream origin main
+git push --set-upstream origin master
 ```
 
 Here, CodeCommit will request the credentials you generated in the **Git Credentials** section. You will only have to provide them once.


### PR DESCRIPTION
Newly created git repositories have a 'master' branch, not a 'main' branch, yes? In my case, I had a 'master' branch. If that's not the convention, at least specify that some repo's will have a default 'master' branch. 

Or configure the CDK code to create a repo with a 'main' branch.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
