### PR TITLE
Update 400-use.md

### DIFF
--- a/workshop/content/english/30-python/40-hit-counter/400-use.md
+++ b/workshop/content/english/30-python/40-hit-counter/400-use.md
@@ -39,7 +39,7 @@ class CdkWorkshopStack(Stack):
 
         apigw.LambdaRestApi(
             self, 'Endpoint',
-            handler=hello_with_counter._handler,
+            handler=hello_with_counter.handler,
         )
 {{</highlight>}}
 


### PR DESCRIPTION
It's a super minor changes. I think we could just use `hello_with_counter.handler` instead of `hello_with__counter._handler` in `CdkWorkshopStack`because we have added `@property` decorator in our to get the handler in our`HitCounter` custom construct, 

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
