### PR TITLE
fix: replaced master with main

### DIFF
--- a/workshop/content/japanese/20-typescript/70-advanced-topics/200-pipelines/2000-create-repo.md
+++ b/workshop/content/japanese/20-typescript/70-advanced-topics/200-pipelines/2000-create-repo.md
@@ -87,10 +87,10 @@ git add -A && git commit -m "Updated .gitignore"
 git remote add origin XXXXX
 ```
 
-最後に、リポジトリにソースコードをプッシュするだけです (`--set-upstream` はリポジトリで空になっている master ブランチを上書きするためです)。
+最後に、リポジトリにソースコードをプッシュするだけです (`--set-upstream` はリポジトリで空になっている main ブランチを上書きするためです)。
 
 ```
-git push --set-upstream origin master
+git push --set-upstream origin main
 ```
 
 ここで CodeCommitの認証情報が求められます。**Git 認証情報** セクションで作成した認証情報を使います。入力するのは 1回目だけです。

--- a/workshop/content/japanese/30-python/70-advanced-topics/200-pipelines/2000-create-repo.md
+++ b/workshop/content/japanese/30-python/70-advanced-topics/200-pipelines/2000-create-repo.md
@@ -68,10 +68,10 @@ cdk deploy
 git remote add origin XXXXX
 ```
 
-最後に、リポジトリにソースコードをプッシュするだけです (`--set-upstream` はリポジトリで空になっている master ブランチを上書きするためです)。
+最後に、リポジトリにソースコードをプッシュするだけです (`--set-upstream` はリポジトリで空になっている main ブランチを上書きするためです)。
 
 ```
-git push --set-upstream origin master
+git push --set-upstream origin main
 ```
 
 ここで CodeCommitの認証情報が求められます。**Git 認証情報** セクションで作成した認証情報を使います。入力するのは 1回目だけです。

--- a/workshop/content/japanese/40-dotnet/70-advanced-topics/100-pipelines/2000-create-repo.md
+++ b/workshop/content/japanese/40-dotnet/70-advanced-topics/100-pipelines/2000-create-repo.md
@@ -76,10 +76,10 @@ npx cdk deploy
 git remote add origin XXXXX
 ```
 
-最後に、リポジトリにソースコードをプッシュするだけです (`--set-upstream` はリポジトリで空になっている master ブランチを上書きするためです)。
+最後に、リポジトリにソースコードをプッシュするだけです (`--set-upstream` はリポジトリで空になっている main ブランチを上書きするためです)。
 
 ```
-git push --set-upstream origin master
+git push --set-upstream origin main
 ```
 
 ここで CodeCommitの認証情報が求められます。**Git 認証情報** セクションで作成した認証情報を使います。入力するのは 1回目だけです。

--- a/workshop/content/japanese/50-java/70-advanced-topics/100-pipelines/2000-create-repo.md
+++ b/workshop/content/japanese/50-java/70-advanced-topics/100-pipelines/2000-create-repo.md
@@ -80,10 +80,10 @@ npx cdk deploy
 git remote add origin XXXXX
 ```
 
-最後に、リポジトリにソースコードをプッシュするだけです (`--set-upstream` はリポジトリで空になっている master ブランチを上書きするためです)。
+最後に、リポジトリにソースコードをプッシュするだけです (`--set-upstream` はリポジトリで空になっている main ブランチを上書きするためです)。
 
 ```
-git push --set-upstream origin master
+git push --set-upstream origin main
 ```
 
 ここで CodeCommitの認証情報が求められます。**Git 認証情報** セクションで作成した認証情報を使います。入力するのは 1回目だけです。


### PR DESCRIPTION
In the Japanese translation the default git branch in all variants (Typescript,  Python, Java, .NET) was still listed as `master`. Updated this to `main` to be in sync with the English version.

Please note: the updated pages contain an image still showing  `master`  in a drop down menu - let me know if you would like to have this updated, too. I have skipped this for the moment as the English version has same inconsistency.  
Links to these images:

* https://cdkworkshop.com/20-typescript/70-advanced-topics/200-pipelines/repo-code.png
* https://cdkworkshop.com/ja/20-typescript/70-advanced-topics/200-pipelines/repo-code.png

Fixes #764
(and stays in conflict with #939 as this PR proposes a change from `main` to `master`. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
