### PR TITLE
Update 400-apigw.md for apigw endpointType support

### DIFF
--- a/workshop/content/english/20-typescript/30-hello-cdk/400-apigw.md
+++ b/workshop/content/english/20-typescript/30-hello-cdk/400-apigw.md
@@ -35,7 +35,9 @@ export class CdkWorkshopStack extends cdk.Stack {
 
     // defines an API Gateway REST API resource backed by our "hello" function.
     new apigw.LambdaRestApi(this, 'Endpoint', {
-      handler: hello
+      handler: hello,
+      // the default EndpointType EDGE is NOT supported in all regions, such as cn-northwest-1. In this case, change the EndpointType to REGIONAL as below.
+      endpointTypes: [apigw.EndpointType.REGIONAL]
     });
 
   }


### PR DESCRIPTION
the default EndpointType EDGE is NOT supported in all regions, such as cn-northwest-1. In this case, change the EndpointType to REGIONAL as below.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
