### PR TITLE
upgrade cdk-dynamo-table-viewer - in order to use Lambda runtime Node v18 (instead of v12)

### DIFF
--- a/workshop/content/english/20-typescript/50-table-viewer/200-install.md
+++ b/workshop/content/english/20-typescript/50-table-viewer/200-install.md
@@ -9,13 +9,13 @@ Before you can use the table viewer in your application, you'll need to install
 the npm module:
 
 ```
-npm install cdk-dynamo-table-viewer@0.2.0
+npm install cdk-dynamo-table-viewer@0.2.46
 ```
 
 Output should look like this:
 
 ```
-+ cdk-dynamo-table-viewer@0.2.0
++ cdk-dynamo-table-viewer@0.2.46
 added 1 package from 1 contributor and audited 886517 packages in 6.704s
 found 0 vulnerabilities
 ```

--- a/workshop/content/japanese/20-typescript/50-table-viewer/200-install.md
+++ b/workshop/content/japanese/20-typescript/50-table-viewer/200-install.md
@@ -8,7 +8,7 @@ weight = 200
 アプリケーションで table viewer を使用するために、npm モジュールをインストールする必要があります。
 
 ```
-npm install cdk-dynamo-table-viewer@0.2.0
+npm install cdk-dynamo-table-viewer@0.2.46
 ```
 
 {{% notice info %}}
@@ -20,7 +20,7 @@ npm install cdk-dynamo-table-viewer@0.2.0
 出力は次のようになります。
 
 ```text
-+ cdk-dynamo-table-viewer@0.2.0
++ cdk-dynamo-table-viewer@0.2.46
 added 1 package from 1 contributor and audited 886517 packages in 6.704s
 found 0 vulnerabilities
 ```


### PR DESCRIPTION
An old version of a dependency package ("cdk-dynamo-table-viewer") used Lambda runtime Node v12, which is no longer supported by AWS.

The dependency package already been updated with Node v18 (and AWS SDK v3) in order to avoid this limitation.

Update the workshop docs with the relevant newer release of cdk-dynamo-table-viewer - version 0.2.46

fixes #1060