### PR TITLE
Update pipeline_stack.py to reference the correct branch (main)

### DIFF
--- a/code/python/pipelines-workshop/cdk_workshop/pipeline_stack.py
+++ b/code/python/pipelines-workshop/cdk_workshop/pipeline_stack.py
@@ -21,7 +21,7 @@ class WorkshopPipelineStack(Stack):
             "Pipeline",
             synth=pipelines.ShellStep(
                 "Synth",
-                input=pipelines.CodePipelineSource.code_commit(repo, "master"),
+                input=pipelines.CodePipelineSource.code_commit(repo, "main"),
                 commands=[
                     "npm install -g aws-cdk",  # Installs the cdk cli on Codebuild
                     "pip install -r requirements.txt",  # Instructs Codebuild to install required packages


### PR DESCRIPTION
Per cdkworkshop.com, the branch is written as main not master. Updating to maintain consistency

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
