### PR TITLE
fix: add deploy before destroy in all english docs

### DIFF
--- a/workshop/content/english/20-typescript/60-cleanups/_index.md
+++ b/workshop/content/english/20-typescript/60-cleanups/_index.md
@@ -64,6 +64,12 @@ export class HitCounter extends Construct {
 }
 {{</highlight>}}
 
+Since we made a change in the construct file, we need to redeploy the stack to put the changes into effect. Use `cdk deploy`:
+
+```
+cdk deploy
+```
+
 Additionally, the Lambda function created will generate CloudWatch logs that are
 permanently retained. These will not be tracked by CloudFormation since they are
 not part of the stack, so the logs will still persist. You will have to manually

--- a/workshop/content/english/30-python/60-cleanups/_index.md
+++ b/workshop/content/english/30-python/60-cleanups/_index.md
@@ -57,6 +57,11 @@ class HitCounter(Construct):
         downstream.grant_invoke(self.handler)
 {{</highlight>}}
 
+Since we made a change in the construct file, we need to redeploy the stack to put the changes into effect. Use `cdk deploy`:
+
+```
+cdk deploy
+```
 
 Additionally, the Lambda function created will generate CloudWatch logs that are
 permanently retained. These will not be tracked by CloudFormation since they are

--- a/workshop/content/english/40-dotnet/60-cleanups/_index.md
+++ b/workshop/content/english/40-dotnet/60-cleanups/_index.md
@@ -70,6 +70,12 @@ namespace CdkWorkshop
 }
 {{</highlight>}}
 
+Since we made a change in the construct file, we need to redeploy the stack to put the changes into effect. Use `cdk deploy`:
+
+```
+cdk deploy
+```
+
 Additionally, the Lambda function created will generate CloudWatch logs that are
 permanently retained. These will not be tracked by CloudFormation since they are
 not part of the stack, so the logs will still persist. You will have to manually

--- a/workshop/content/english/60-go/60-cleanups/_index.md
+++ b/workshop/content/english/60-go/60-cleanups/_index.md
@@ -76,6 +76,11 @@ func (h *hitCounter) Table() awsdynamodb.Table {
 
 {{</highlight>}}
 
+Since we made a change in the construct file, we need to redeploy the stack to put the changes into effect. Use `cdk deploy`:
+
+```
+cdk deploy
+```
 
 Additionally, the Lambda function created will generate CloudWatch logs that are
 permanently retained. These will not be tracked by CloudFormation since they are


### PR DESCRIPTION
Fixes # 1131

Running through the TS sample, i followed to the letter and then didn't get my DB deleted after destroy. The docs could be improved with the suggestion of deploying prior to destroy...  checking the other languages, Java had this but none of the other languages. So i duplicated it's exact text for all other languages.

NOTE: Japanese still does not have this.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
