### PR TITLE
fix: cdk-dynamo-table-viewer version fails deployment due to unsupported node version

### DIFF
--- a/workshop/content/english/20-typescript/50-table-viewer/200-install.md
+++ b/workshop/content/english/20-typescript/50-table-viewer/200-install.md
@@ -9,7 +9,7 @@ Before you can use the table viewer in your application, you'll need to install
 the npm module:
 
 ```
-npm install cdk-dynamo-table-viewer@0.2.46
+npm install cdk-dynamo-table-viewer@0.2.486
 ```
 
 Output should look like this:

--- a/workshop/content/japanese/20-typescript/50-table-viewer/200-install.md
+++ b/workshop/content/japanese/20-typescript/50-table-viewer/200-install.md
@@ -8,7 +8,7 @@ weight = 200
 アプリケーションで table viewer を使用するために、npm モジュールをインストールする必要があります。
 
 ```
-npm install cdk-dynamo-table-viewer@0.2.46
+npm install cdk-dynamo-table-viewer@0.2.486
 ```
 
 {{% notice info %}}


### PR DESCRIPTION
Fixes https://github.com/aws-samples/aws-cdk-intro-workshop/issues/1139

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
