### PR TITLE
fix(python): improve python packaging related wording

### DIFF
--- a/workshop/content/english/30-python/40-hit-counter/700-test.md
+++ b/workshop/content/english/30-python/40-hit-counter/700-test.md
@@ -35,7 +35,8 @@ The cool thing about our `HitCounter` is that it's quite useful. It basically
 allows anyone to "attach" it to any Lambda function that serves as an API
 Gateway proxy backend and it will log hits to this API.
 
-Since our hit counter is a simple Python class, you could package it and then publish to [PyPI](http://pypi.org/), the default Package Index for the Python community. Then, anyone could `pip install` it and add it to
+Since our hit counter is a simple Python class, you could package it and then publish to [PyPI](http://pypi.org/),
+the default Package Index for the Python community. Then, anyone could `pip install` it and add it to
 their CDK apps.
 
 -----

--- a/workshop/content/english/30-python/40-hit-counter/700-test.md
+++ b/workshop/content/english/30-python/40-hit-counter/700-test.md
@@ -35,9 +35,7 @@ The cool thing about our `HitCounter` is that it's quite useful. It basically
 allows anyone to "attach" it to any Lambda function that serves as an API
 Gateway proxy backend and it will log hits to this API.
 
-Since our hit counter is a simple Python class, you could package it into a
-pip module and publish it to [PyPi](http://pypi.org/), which is the
-Python package manager. Then, anyone could `pip install` it and add it to
+Since our hit counter is a simple Python class, you could package it and then publish to [PyPI](http://pypi.org/), the default Package Index for the Python community. Then, anyone could `pip install` it and add it to
 their CDK apps.
 
 -----


### PR DESCRIPTION
This is an attempt to improve the wording related to python packaging in `700-test.html`

Rationale:
> package it into a pip module

strictly speaking there are no pip modules, those are packages ([source](https://packaging.python.org/en/latest/glossary/#term-Import-Package))

> [PyPi](http://pypi.org/), which is the Python package manager

PyPI is the default Package Index for the Python community. ([source](https://packaging.python.org/en/latest/glossary/#term-Python-Package-Index-PyPI))

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
