### PR TITLE
feat: use new `TableV2` construct

### DIFF
--- a/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
@@ -9,10 +9,9 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       code: lambda.Code.fromAsset('lambda'),
       handler: 'hello.handler',
-
     });
 
     const helloWithCounter = new HitCounter(this, 'HelloHitCounter', {

--- a/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
+++ b/code/typescript/main-workshop/lib/cdk-workshop-stack.ts
@@ -26,8 +26,9 @@ export class CdkWorkshopStack extends cdk.Stack {
 
     new TableViewer(this, 'ViewHitCounter', {
       title: 'Hello Hits',
-      table: helloWithCounter.table,
-      sortBy: '-hits'
+      // table: helloWithCounter.table, /** when cdk-dynamo-table-viewer supports TableV2 (https://github.com/cdklabs/cdk-dynamo-table-viewer/pull/737) */
+      table: helloWithCounter.table as any,
+      sortBy: '-hits',
     });
   }
 }

--- a/code/typescript/main-workshop/lib/hitcounter.ts
+++ b/code/typescript/main-workshop/lib/hitcounter.ts
@@ -12,12 +12,12 @@ export class HitCounter extends Construct {
   public readonly handler: lambda.Function;
 
   /** the hit counter table */
-  public readonly table: dynamodb.Table;
+  public readonly table: dynamodb.TableV2;
 
   constructor(scope: Construct, id: string, props: HitCounterProps) {
     super(scope, id);
 
-    const table = new dynamodb.Table(this, 'Hits', {
+    const table = new dynamodb.TableV2(this, 'Hits', {
       partitionKey: { name: 'path', type: dynamodb.AttributeType.STRING }
     });
     this.table = table;

--- a/code/typescript/main-workshop/package-lock.json
+++ b/code/typescript/main-workshop/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cdk-main-workshop",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.76.0",
+        "aws-cdk-lib": "^2.96.2",
         "cdk-dynamo-table-viewer": "^0.2.461",
         "constructs": "^10.0.5"
       },
@@ -38,19 +38,19 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.185",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.185.tgz",
-      "integrity": "sha512-cost0pu5nsmQmFhVxN4OonThGhgQeSlwntdXsEi5v8buVg+X4MzcXemmmSZxkkzzFCoS0r4w/7BiX1e+mMkFVA=="
+      "version": "2.2.200",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
+      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
-      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.155",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.155.tgz",
-      "integrity": "sha512-Q+Ny25hUPINlBbS6lmbUr4m6Tr6ToEJBla7sXA3FO3JUD0Z69ddcgbhuEBF8Rh1a2xmPONm89eX77kwK2fb4vQ=="
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
+      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.21.4",
@@ -1248,9 +1248,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.81.0.tgz",
-      "integrity": "sha512-jnXvyhyRvoFTQcpZPtZOeOyY7k4Jb1+c83RLFic71KrwL6xxLxzImbS5rnoDOJHaX/otyfDxzQfziOQ7I0kt/g==",
+      "version": "2.97.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.97.0.tgz",
+      "integrity": "sha512-O9LYiQcaJTngaz4wocMw6RIcPs7jhIXE1k+2uEBrf6UqaH/nxa18wd4q5Mw7+jNFLkR37Ivw6XF/RYA5ZcREKw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1264,9 +1264,9 @@
         "yaml"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.177",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
+        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.1.1",
@@ -1274,7 +1274,7 @@
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.0",
-        "semver": "^7.5.1",
+        "semver": "^7.5.4",
         "table": "^6.8.1",
         "yaml": "1.10.2"
       },
@@ -1490,7 +1490,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.1",
+      "version": "7.5.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6562,19 +6562,19 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.185",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.185.tgz",
-      "integrity": "sha512-cost0pu5nsmQmFhVxN4OonThGhgQeSlwntdXsEi5v8buVg+X4MzcXemmmSZxkkzzFCoS0r4w/7BiX1e+mMkFVA=="
+      "version": "2.2.200",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
+      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg=="
     },
     "@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
-      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.155",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.155.tgz",
-      "integrity": "sha512-Q+Ny25hUPINlBbS6lmbUr4m6Tr6ToEJBla7sXA3FO3JUD0Z69ddcgbhuEBF8Rh1a2xmPONm89eX77kwK2fb4vQ=="
+    "@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
+      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
     },
     "@babel/code-frame": {
       "version": "7.21.4",
@@ -7526,13 +7526,13 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.81.0.tgz",
-      "integrity": "sha512-jnXvyhyRvoFTQcpZPtZOeOyY7k4Jb1+c83RLFic71KrwL6xxLxzImbS5rnoDOJHaX/otyfDxzQfziOQ7I0kt/g==",
+      "version": "2.97.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.97.0.tgz",
+      "integrity": "sha512-O9LYiQcaJTngaz4wocMw6RIcPs7jhIXE1k+2uEBrf6UqaH/nxa18wd4q5Mw7+jNFLkR37Ivw6XF/RYA5ZcREKw==",
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.177",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
+        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.1.1",
@@ -7540,7 +7540,7 @@
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.0",
-        "semver": "^7.5.1",
+        "semver": "^7.5.4",
         "table": "^6.8.1",
         "yaml": "1.10.2"
       },
@@ -7677,7 +7677,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "7.5.1",
+          "version": "7.5.4",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"

--- a/code/typescript/main-workshop/package.json
+++ b/code/typescript/main-workshop/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.76.0",
+    "aws-cdk-lib": "^2.96.2",
     "constructs": "^10.0.5",
     "cdk-dynamo-table-viewer": "^0.2.461"
   }


### PR DESCRIPTION
Updated the aws-cdk-lib version to ^2.96.2 in the typescript > main workshop directory (I did not know if this version bump needed to be more widespread). This allows the use of dynamo's `TableV2` construct.

Then updated the code to use `TableV2`. ~Currently, there needs to be a workaround so that TableViewer can accept a `TableV2` as a parameter. I included that workaround, but I also put the future code in a comment with a link to track the feature ([link](https://github.com/cdklabs/cdk-dynamo-table-viewer/pull/737)).~ TableV2 is supported in release 0.2.487. Will update the import statement (related to #1140).

Fixes #1178.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
