### PR TITLE
Bump dependency (Java) to cdk-dynamo-table-view to version 0.2.487

### DIFF
--- a/workshop/content/english/50-java/50-table-viewer/200-install.md
+++ b/workshop/content/english/50-java/50-table-viewer/200-install.md
@@ -21,7 +21,7 @@ Before you can use the table viewer in your application, you'll need to add the 
         <dependency>
             <groupId>io.github.cdklabs</groupId>
             <artifactId>cdk-dynamo-table-view</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.487</version>
             <exclusions>
                 <exclusion>
                     <groupId> software.amazon.jsii</groupId>

--- a/workshop/content/japanese/50-java/50-table-viewer/200-install.md
+++ b/workshop/content/japanese/50-java/50-table-viewer/200-install.md
@@ -21,7 +21,7 @@ weight = 200
         <dependency>
             <groupId>io.github.cdklabs</groupId>
             <artifactId>cdk-dynamo-table-view</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.487</version>
             <exclusions>
                 <exclusion>
                     <groupId> software.amazon.jsii</groupId>


### PR DESCRIPTION
This commit bumps the dependency to cdk-dynamo-table-view as version 0.2 uses node 12 which is not supported by AWS anymore and the deployment fails.

Fixes #1231 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
