### PR TITLE
fix: Update Lambda to Node.js 18

### DIFF
--- a/workshop/content/english/30-python/50-table-viewer/200-install.md
+++ b/workshop/content/english/30-python/50-table-viewer/200-install.md
@@ -11,7 +11,7 @@ the python module. Add this code to `requirements.txt`:
 {{<highlight python "hl_lines=3">}}
 aws-cdk-lib==2.37.0
 constructs>=10.0.0,<11.0.0
-cdk-dynamo-table-view==0.2.0
+cdk-dynamo-table-view==0.2.488
 {{</highlight>}}
 
 Once the virtualenv is activated, you can install the required dependencies.


### PR DESCRIPTION
The node 12 runtime is deprecated. This updates the documentation to a table view version with the node 18 runtime.

https://github.com/cdklabs/cdk-dynamo-table-viewer/issues/450

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes #1231 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
