### PR TITLE
change package version from 0.2.0 to 0.2.488

### DIFF
--- a/workshop/content/english/30-python/50-table-viewer/200-install.md
+++ b/workshop/content/english/30-python/50-table-viewer/200-install.md
@@ -24,7 +24,7 @@ The last two lines of the output (there's a lot of it) should look like this:
 
 ```
 Installing collected packages: cdk-dynamo-table-view
-Successfully installed cdk-dynamo-table-view-0.2.0
+Successfully installed cdk-dynamo-table-view-0.2.488
 ```
 
 ----

--- a/workshop/content/english/30-python/50-table-viewer/200-install.md
+++ b/workshop/content/english/30-python/50-table-viewer/200-install.md
@@ -11,7 +11,7 @@ the python module. Add this code to `requirements.txt`:
 {{<highlight python "hl_lines=3">}}
 aws-cdk-lib==2.37.0
 constructs>=10.0.0,<11.0.0
-cdk-dynamo-table-view==0.2.0
+cdk-dynamo-table-view==0.2.488
 {{</highlight>}}
 
 Once the virtualenv is activated, you can install the required dependencies.


### PR DESCRIPTION
Fix fatal error where Node 12 is no longer supported.  As of this commit, 0.2.488 is the latest version of cdk-dynamo-table-view, and version 0.2.0 is no longer supported by AWS because of NodeJS 12.x support.

<!--
When using package 0.2.0, this error is returned when running cdk deploy:

Resource handler returned message: "The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs18.x) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: xxx)" (RequestToken: xxx, HandlerErrorCode: InvalidRequest)

There is an updated version of the cdk-dynamo-table-view package where the Node version for the lambda runtime has been updated.
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
