### PR TITLE
Update 2000-validation-tests.md --> deprecated jest function

### DIFF
--- a/workshop/content/english/20-typescript/70-advanced-topics/100-construct-testing/2000-validation-tests.md
+++ b/workshop/content/english/20-typescript/70-advanced-topics/100-construct-testing/2000-validation-tests.md
@@ -76,7 +76,7 @@ test('read capacity can be configured', () => {
       }),
       readCapacity: 3
     });
-  }).toThrowError(/readCapacity must be greater than 5 and less than 20/);
+  }).toThrow(/readCapacity must be greater than 5 and less than 20/);
 });
 ```
 


### PR DESCRIPTION
Jest method "toThrowError()" is deprecated. The valid method is "toThrow()".


<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
