### PR TITLE
Update 200-install.md

### DIFF
--- a/workshop/content/english/30-python/50-table-viewer/200-install.md
+++ b/workshop/content/english/30-python/50-table-viewer/200-install.md
@@ -9,9 +9,9 @@ Before you can use the table viewer in your application, you'll need to install
 the python module. Add this code to `requirements.txt`:
 
 {{<highlight python "hl_lines=3">}}
-aws-cdk-lib==2.37.0
+aws-cdk-lib==2.128.0
 constructs>=10.0.0,<11.0.0
-cdk-dynamo-table-view==0.2.0
+cdk-dynamo-table-view==0.2.488
 {{</highlight>}}
 
 Once the virtualenv is activated, you can install the required dependencies.


### PR DESCRIPTION
The workshop started with `aws-cdk-lib==2.128.0` version then when it came to install `cdk-dynamo-table-view` suddenly the `aws-cdk-lib` upgraded to `2.37.0` which is not compatible with python version 3.10.X. It's better to downgrade it.

Also, you are using `0.2.0` version for `cdk-dynamo-table-view` module which uses` "Runtime": "nodejs12.x"` and nodejs12 is deprecated. I installed `0.2.488` version for `cdk-dynamo-table-view` so now I can deploy the stack seamlessly.

FYI, I'm using PYTHON_3_10 for lambda runtime as the PYTHON_3_7 is also deprecated.

It's better also to upgrade lambda runtime, please. Could you please update the doc for other fellows too?

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
