### PR TITLE
Fix 'Cannot find name 'path'' error

### DIFF
--- a/workshop/content/english/20-typescript/30-hello-cdk/400-apigw.md
+++ b/workshop/content/english/20-typescript/30-hello-cdk/400-apigw.md
@@ -22,6 +22,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import * as path from 'path';
+
 export class CdkWorkshopStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, id, props);

--- a/workshop/content/english/20-typescript/30-hello-cdk/400-apigw.md
+++ b/workshop/content/english/20-typescript/30-hello-cdk/400-apigw.md
@@ -21,7 +21,7 @@ Going back to `lib/cdk-workshop-stack.ts`, let's define an API endpoint and asso
 import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
-
+import * as path from 'path';
 export class CdkWorkshopStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, id, props);


### PR DESCRIPTION
This fix addresses a TypeScript error where the compiler cannot recognize the 'path' module. It ensures proper import of the 'path' module, resolving the error "Cannot find name 'path'"

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
