### PR TITLE
Update 400-use.md

### DIFF
--- a/workshop/content/english/20-typescript/40-hit-counter/400-use.md
+++ b/workshop/content/english/20-typescript/40-hit-counter/400-use.md
@@ -19,7 +19,7 @@ export class CdkWorkshopStack extends cdk.Stack {
     super(scope, id, props);
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       code: lambda.Code.fromAsset('lambda'),
       handler: 'hello.handler'
     });


### PR DESCRIPTION
NODEJS_14_X is deprecated and no longer supported by AWS, therefore the version should be upgraded to at least 16.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
