### PR TITLE
changed "template app" to "template sample-app"

### DIFF
--- a/workshop/content/english/20-typescript/20-create-project/100-cdk-init.md
+++ b/workshop/content/english/20-typescript/20-create-project/100-cdk-init.md
@@ -24,7 +24,7 @@ initialization of a git repository, this probably means you don't have git
 installed, which is fine for this workshop):
 
 ```
-Applying project template app for typescript
+Applying project template sample-app for typescript
 Initializing a new git repository...
 Executing npm install...
 npm notice created a lockfile as package-lock.json. You should commit this file.


### PR DESCRIPTION
Amended the cdk init output text to show the same name of the template to make it consistent with the workshop instructions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0/blob/master/MIT-0
